### PR TITLE
Move to Rust 2018 edition and use serde serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Implements the MAVLink data interchange format for UAVs."
 readme = "README.md"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mavlink/rust-mavlink"
+edition = "2018"
 
 [build-dependencies]
 crc16 = "0.3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ xml-rs = "0.2"
 quote = "0.3"
 rustfmt = "0.9"
 lazy_static = "1.2.0"
+serde = "1.0.101"
 
 [[bin]]
 name = "mavlink-dump"
@@ -28,6 +29,7 @@ num-traits = "0.2"
 num-derive = "0.2"
 bitflags = "1.0.4"
 serial = { version = "0.4", optional = true }
+serde = "1.0.101"
 
 [dependencies.byteorder]
 version = "0.5.3"

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -7,7 +7,9 @@ use xml::reader::{EventReader, XmlEvent};
 
 use quote::{Ident, Tokens};
 
-#[derive(Debug, PartialEq, Clone, Default)]
+use serde::Serialize;
+
+#[derive(Serialize, Debug, PartialEq, Clone, Default)]
 pub struct MavProfile {
     pub includes: Vec<String>,
     pub messages: Vec<MavMessage>,
@@ -141,6 +143,8 @@ impl MavProfile {
             use num_traits::FromPrimitive;
             use bitflags::bitflags;
 
+            use serde::Serialize;
+
             #[cfg(not(feature = "std"))]
             use alloc::vec::Vec;
 
@@ -167,6 +171,8 @@ impl MavProfile {
 
     fn emit_mav_message(&self, enums: Vec<Tokens>, structs: Vec<Tokens>) -> Tokens {
         quote!{
+                #[derive(Serialize)]
+                #[serde(tag = "type")]
                 pub enum MavMessage {
                     #(#enums(#structs)),*
                 }
@@ -212,7 +218,7 @@ impl MavProfile {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Debug, PartialEq, Clone, Default)]
 pub struct MavEnum {
     pub name: String,
     pub description: Option<String>,
@@ -263,6 +269,7 @@ impl MavEnum {
             let width = Ident::from(width);
             enum_def = quote!{
                 bitflags!{
+                    #[derive(Serialize)]
                     pub struct #enum_name: #width {
                         #(#defs)*
                     }
@@ -270,7 +277,8 @@ impl MavEnum {
             };
         } else {
             enum_def = quote!{
-                #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive)]
+                #[derive(Serialize, Debug, Copy, Clone, PartialEq, FromPrimitive)]
+                #[serde(tag = "type")]
                 pub enum #enum_name {
                     #(#defs)*
                 }
@@ -289,7 +297,7 @@ impl MavEnum {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Debug, PartialEq, Clone, Default)]
 pub struct MavEnumEntry {
     pub value: Option<i32>,
     pub name: String,
@@ -297,7 +305,7 @@ pub struct MavEnumEntry {
     pub params: Option<Vec<String>>,
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Debug, PartialEq, Clone, Default)]
 pub struct MavMessage {
     pub id: u32,
     pub name: String,
@@ -409,7 +417,7 @@ impl MavMessage {
 
         quote!{
             #description
-            #[derive(Debug, Clone, PartialEq, Default)]
+            #[derive(Serialize, Debug, Clone, PartialEq, Default)]
             pub struct #msg_name {
                 #(#name_types)*
             }
@@ -429,7 +437,7 @@ impl MavMessage {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Serialize, Debug, PartialEq, Clone, Default)]
 pub struct MavField {
     pub mavtype: MavType,
     pub name: String,
@@ -533,7 +541,7 @@ impl MavField {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Serialize, Debug, PartialEq, Clone)]
 pub enum MavType {
     UInt8MavlinkVersion,
     UInt8,
@@ -734,7 +742,8 @@ impl MavType {
 
 
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Serialize, Debug, PartialEq, Clone, Copy)]
+#[serde(tag = "type")]
 pub enum MavXmlElement {
     Version,
     Mavlink,

--- a/src/connection/direct_serial.rs
+++ b/src/connection/direct_serial.rs
@@ -3,12 +3,12 @@ extern crate serial;
 
 use std::sync::Mutex;
 use std::io::{self};
-use connection::MavConnection;
+use crate::connection::MavConnection;
 use crate::common::MavMessage;
 use crate::{read_versioned_msg, write_versioned_msg, MavHeader, MavlinkVersion};
 
 //TODO why is this import so hairy?
-use connection::direct_serial::serial::prelude::*;
+use crate::connection::direct_serial::serial::prelude::*;
 
 
 /// Serial MAVLINK connection
@@ -45,7 +45,7 @@ pub fn open(settings: &str) -> io::Result<SerialConnection> {
 
     let port_name = settings_toks[0];
     let mut port  = serial::open(port_name)?;
-    try!(port.configure(&settings));
+    port.configure(&settings)?;
 
     Ok(SerialConnection {
         port: Mutex::new(port),

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use std::sync::Mutex;
 use std::net::{ToSocketAddrs};
 use std::io::{self};
-use connection::MavConnection;
+use crate::connection::MavConnection;
 use crate::common::MavMessage;
 use crate::{read_versioned_msg, write_versioned_msg, MavHeader, MavlinkVersion};
 

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::sync::Mutex;
 use std::net::{ToSocketAddrs};
 use std::io::{self};
-use connection::MavConnection;
+use crate::connection::MavConnection;
 use crate::common::MavMessage;
 use crate::{read_versioned_msg, write_versioned_msg, MavHeader, MavlinkVersion};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ extern crate bitflags;
 #[allow(unused_variables)]
 #[allow(unused_mut)]
 pub mod common {
-    use MavlinkVersion; //TODO verify
+    use crate::MavlinkVersion; //TODO verify
     include!(concat!(env!("OUT_DIR"), "/common.rs"));
 }
 

--- a/tests/encode_decode_tests.rs
+++ b/tests/encode_decode_tests.rs
@@ -10,11 +10,11 @@ mod test_encode_decode {
     #[test]
     pub fn test_echo_heartbeat() {
         let mut v = vec![];
-        let send_msg = ::test_shared::get_heartbeat_msg();
+        let send_msg = crate::test_shared::get_heartbeat_msg();
 
         mavlink::write_v2_msg(
             &mut v,
-            ::test_shared::COMMON_MSG_HEADER,
+            crate::test_shared::COMMON_MSG_HEADER,
             &mavlink::common::MavMessage::HEARTBEAT(send_msg.clone()),
         ).expect("Failed to write message");
 
@@ -26,11 +26,11 @@ mod test_encode_decode {
     #[test]
     pub fn test_echo_command_int() {
         let mut v = vec![];
-        let send_msg = ::test_shared::get_cmd_nav_takeoff_msg();
+        let send_msg = crate::test_shared::get_cmd_nav_takeoff_msg();
 
         mavlink::write_v2_msg(
             &mut v,
-            ::test_shared::COMMON_MSG_HEADER,
+            crate::test_shared::COMMON_MSG_HEADER,
             &mavlink::common::MavMessage::COMMAND_INT(send_msg.clone()),
         ).expect("Failed to write message");
 
@@ -47,11 +47,11 @@ mod test_encode_decode {
     #[test]
     pub fn test_echo_hil_actuator_controls() {
         let mut v = vec![];
-        let send_msg = ::test_shared::get_hil_actuator_controls_msg();
+        let send_msg = crate::test_shared::get_hil_actuator_controls_msg();
 
         mavlink::write_v2_msg(
             &mut v,
-            ::test_shared::COMMON_MSG_HEADER,
+            crate::test_shared::COMMON_MSG_HEADER,
             &mavlink::common::MavMessage::HIL_ACTUATOR_CONTROLS(send_msg.clone()),
         ).expect("Failed to write message");
 

--- a/tests/tcp_loopback_tests.rs
+++ b/tests/tcp_loopback_tests.rs
@@ -45,7 +45,7 @@ mod test_tcp_connections {
         // have the client send a few hearbeats
         thread::spawn({
             move || {
-                let msg = mavlink::common::MavMessage::HEARTBEAT( ::test_shared::get_heartbeat_msg() );
+                let msg = mavlink::common::MavMessage::HEARTBEAT( crate::test_shared::get_heartbeat_msg() );
                 let client = mavlink::connect("tcpout:127.0.0.1:14550")
                     .expect("Couldn't create client");
                 for _i in 0..RECEIVE_CHECK_COUNT {

--- a/tests/udp_loopback_tests.rs
+++ b/tests/udp_loopback_tests.rs
@@ -19,7 +19,7 @@ mod test_udp_connections {
         // have the client send one heartbeat per second
         thread::spawn({
             move || {
-                let msg = mavlink::common::MavMessage::HEARTBEAT( ::test_shared::get_heartbeat_msg() );
+                let msg = mavlink::common::MavMessage::HEARTBEAT( crate::test_shared::get_heartbeat_msg() );
                 let client = mavlink::connect("udpout:127.0.0.1:14551")
                     .expect("Couldn't create client");
                 loop {

--- a/tests/v1_encode_decode_tests.rs
+++ b/tests/v1_encode_decode_tests.rs
@@ -19,8 +19,8 @@ mod test_v1_encode_decode {
         let (header, msg) = mavlink::read_v1_msg(&mut r).expect("Failed to parse message");
         //println!("{:?}, {:?}", header, msg);
 
-        assert_eq!(header, ::test_shared::COMMON_MSG_HEADER);
-        let heartbeat_msg = ::test_shared::get_heartbeat_msg();
+        assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
+        let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
 
         if let mavlink::common::MavMessage::HEARTBEAT(msg) = msg {
             assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
@@ -37,10 +37,10 @@ mod test_v1_encode_decode {
     #[test]
     pub fn test_write_heartbeat() {
         let mut v = vec![];
-        let heartbeat_msg = ::test_shared::get_heartbeat_msg();
+        let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
         mavlink::write_v1_msg(
             &mut v,
-            ::test_shared::COMMON_MSG_HEADER,
+            crate::test_shared::COMMON_MSG_HEADER,
             &mavlink::common::MavMessage::HEARTBEAT(heartbeat_msg.clone()),
         )
             .expect("Failed to write message");

--- a/tests/v2_encode_decode_tests.rs
+++ b/tests/v2_encode_decode_tests.rs
@@ -26,8 +26,8 @@ mod test_v2_encode_decode {
         let mut r = HEARTBEAT_V2;
         let (header, msg) = mavlink::read_v2_msg(&mut r).expect("Failed to parse message");
 
-        assert_eq!(header, ::test_shared::COMMON_MSG_HEADER);
-        let heartbeat_msg = ::test_shared::get_heartbeat_msg();
+        assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
+        let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
 
         if let mavlink::common::MavMessage::HEARTBEAT(msg) = msg {
             assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
@@ -44,10 +44,10 @@ mod test_v2_encode_decode {
     #[test]
     pub fn test_write_v2_heartbeat() {
         let mut v = vec![];
-        let heartbeat_msg = ::test_shared::get_heartbeat_msg();
+        let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
         mavlink::write_v2_msg(
             &mut v,
-            ::test_shared::COMMON_MSG_HEADER,
+            crate::test_shared::COMMON_MSG_HEADER,
             &mavlink::common::MavMessage::HEARTBEAT(heartbeat_msg.clone()),
         )
             .expect("Failed to write message");


### PR DESCRIPTION
- Move to Rust 2018 edition, helping the integration with new crates and some [general corrections](https://github.com/rust-lang-nursery/edition-guide/blob/5521dada71a232403bcce6870eed92897590561e/src/rust-2018/edition-changes.md).
- Use serde serialization to allow generic and more common data access in a generic format.
    - The problem with the messages defined inside enums does not allows the users to use the library in a generic way, resulting in a match/case for each enum for each message to access content. This makes any kind of generic programming almost impossible without hacks around the types and generated code.
    - To fix this problem, this patchs uses [serde crate](https://crates.io/crates/serde), that helps with the transformation between the most popular formats:

![image](https://user-images.githubusercontent.com/1215497/66707715-96b73600-ed1b-11e9-8cee-3c3f57901e91.png)

ref: [serde.rs](https://serde.rs)
