### PR TITLE
Parse: Flags: Improve expected message and force bits validation 

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -548,7 +548,7 @@ impl MavField {
                     let enum_name = Ident::from(enum_name.clone());
                     quote!{
                         #tmp
-                        #name = #enum_name::from_bits(tmp).expect("Unexpected enum value.");
+                        #name = #enum_name::from_bits(tmp & #enum_name::all().bits()).expect("Unexpected enum value.");
                     }
 
                 } else {

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -548,7 +548,7 @@ impl MavField {
                     let enum_name = Ident::from(enum_name.clone());
                     quote!{
                         #tmp
-                        #name = #enum_name::from_bits(tmp & #enum_name::all().bits()).expect("Unexpected enum value.");
+                        #name = #enum_name::from_bits(tmp & #enum_name::all().bits()).expect(&format!("Unexpected flags value {}", tmp));
                     }
 
                 } else {


### PR DESCRIPTION
Some vehicles can set and send bits that are not used/declared in the message definition. 