### PR TITLE
Derive PartialEq & Eq traits for MavlinkVersion

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub struct MavHeader {
 }
 
 /// Versions of the Mavlink protocol that we support
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 pub enum MavlinkVersion {


### PR DESCRIPTION
This allows easy checks for the correct mavlink version, e.g. `assert_eq!(mav.get_protocol_version(), MavlinkVersion::V2);`