### PR TITLE
parser: Do not serialize length of fixed size vectors

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -681,7 +681,6 @@ impl MavType {
             Array(t,_size) => {
                 let w = t.rust_writer(Ident::from("*val"), buf.clone());
                 quote!{
-                    #buf.put_u8(#val.len() as u8);
                     for val in &#val {
                         #w
                     }


### PR DESCRIPTION
Adding the size of fixed size vectors breaks binary compatibility with the structure definition of the XML files.
As example, this is the actual output with VIDEO_STREAM_INFORMATION_DATA
```rust
    pub fn ser(&self) -> Vec<u8> {
        let mut _tmp = Vec::new();
        _tmp.put_f32_le(self.framerate);
        _tmp.put_u32_le(self.bitrate);
        _tmp.put_u16_le(self.flags as u16);
        _tmp.put_u16_le(self.resolution_h);
        _tmp.put_u16_le(self.resolution_v);
        _tmp.put_u16_le(self.rotation);
        _tmp.put_u16_le(self.hfov);
        _tmp.put_u8(self.stream_id);
        _tmp.put_u8(self.count);
        _tmp.put_u8(self.mavtype as u8);
        _tmp.put_u8(self.name.len() as u8);
        for val in &self.name {
            _tmp.put_u8(*val as u8);
        }
        _tmp.put_u8(self.uri.len() as u8);
        for val in &self.uri {
            _tmp.put_u8(*val as u8);
        }
        _tmp
    }
```

And this is the output of mavlink c library:
```cpp
MAVPACKED(
typedef struct __mavlink_video_stream_information_t {
 float framerate; /*< [Hz] Frame rate.*/
 uint32_t bitrate; /*< [bits/s] Bit rate.*/
 uint16_t flags; /*<  Bitmap of stream status flags.*/
 uint16_t resolution_h; /*< [pix] Horizontal resolution.*/
 uint16_t resolution_v; /*< [pix] Vertical resolution.*/
 uint16_t rotation; /*< [deg] Video image rotation clockwise.*/
 uint16_t hfov; /*< [deg] Horizontal Field of view.*/
 uint8_t stream_id; /*<  Video Stream ID (1 for first, 2 for second, etc.)*/
 uint8_t count; /*<  Number of streams available.*/
 uint8_t type; /*<  Type of stream.*/
 char name[32]; /*<  Stream name.*/
 char uri[160]; /*<  Video stream URI (TCP or RTSP URI ground station should connect to) or port number (UDP port ground station should listen to).*/
}) mavlink_video_stream_information_t;
....

#if MAVLINK_COMMAND_24BIT
#define MAVLINK_MESSAGE_INFO_VIDEO_STREAM_INFORMATION { \
    269, \
    "VIDEO_STREAM_INFORMATION", \
    12, \
    {  { "stream_id", NULL, MAVLINK_TYPE_UINT8_T, 0, 18, offsetof(mavlink_video_stream_information_t, stream_id) }, \
         { "count", NULL, MAVLINK_TYPE_UINT8_T, 0, 19, offsetof(mavlink_video_stream_information_t, count) }, \
         { "type", NULL, MAVLINK_TYPE_UINT8_T, 0, 20, offsetof(mavlink_video_stream_information_t, type) }, \
         { "flags", NULL, MAVLINK_TYPE_UINT16_T, 0, 8, offsetof(mavlink_video_stream_information_t, flags) }, \
         { "framerate", NULL, MAVLINK_TYPE_FLOAT, 0, 0, offsetof(mavlink_video_stream_information_t, framerate) }, \
         { "resolution_h", NULL, MAVLINK_TYPE_UINT16_T, 0, 10, offsetof(mavlink_video_stream_information_t, resolution_h) }, \
         { "resolution_v", NULL, MAVLINK_TYPE_UINT16_T, 0, 12, offsetof(mavlink_video_stream_information_t, resolution_v) }, \
         { "bitrate", NULL, MAVLINK_TYPE_UINT32_T, 0, 4, offsetof(mavlink_video_stream_information_t, bitrate) }, \
         { "rotation", NULL, MAVLINK_TYPE_UINT16_T, 0, 14, offsetof(mavlink_video_stream_information_t, rotation) }, \
         { "hfov", NULL, MAVLINK_TYPE_UINT16_T, 0, 16, offsetof(mavlink_video_stream_information_t, hfov) }, \
         { "name", NULL, MAVLINK_TYPE_CHAR, 32, 21, offsetof(mavlink_video_stream_information_t, name) }, \
         { "uri", NULL, MAVLINK_TYPE_CHAR, 160, 53, offsetof(mavlink_video_stream_information_t, uri) }, \
         } \
}
```

As you can see, the `_tmp.put_u8(self.name.len() as u8);` and `_tmp.put_u8(self.uri.len() as u8);` breaks compatibility with the definition. 

Tested and working like a charm in QGC, fix the actual failed behavior. 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>