### PR TITLE
parser: Deal with extensions keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ optional = true
 
 [features]
 "emit-description" = []
+"emit-extensions" = []
 "std" = ["byteorder"]
 "udp" = []
 "tcp" = []


### PR DESCRIPTION
Add feature emit-extensions to allow builds with such messages, by default we ignore it 

Improve support for other dialects

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>