### PR TITLE
Return Results instead of panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "mavlink"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Todd Stellanova", "Michal Podhradsky", "Kevin Mehall", "Tim Ryan", "Patrick José Pereira", "Ibiyemi Abiodun"]
 build = "build/main.rs"
 description = "Implements the MAVLink data interchange format for UAVs."

--- a/build/main.rs
+++ b/build/main.rs
@@ -89,7 +89,7 @@ pub fn main() {
             Err(error) => eprintln!("{}", error),
         }
 
-        // Re-run build if common.xml changes
+        // Re-run build if definition file changes
         println!("cargo:rerun-if-changed={}", entry.path().to_string_lossy());
     }
 

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -236,8 +236,8 @@ impl MavProfile {
         // range for this message
         let includes_branches = includes.into_iter().map(|i| {
             quote! {
-                if let Some(msg) = crate::#i::MavMessage::parse(version, id, payload) {
-                    return Some(MavMessage::#i(msg))
+                if let Ok(msg) = crate::#i::MavMessage::parse(version, id, payload) {
+                    return Ok(MavMessage::#i(msg))
                 }
             }
         });

--- a/src/bin/mavlink-dump.rs
+++ b/src/bin/mavlink-dump.rs
@@ -1,3 +1,4 @@
+use mavlink::error::MessageReadError;
 #[cfg(feature = "std")]
 use std::env;
 #[cfg(feature = "std")]
@@ -6,7 +7,6 @@ use std::sync::Arc;
 use std::thread;
 #[cfg(feature = "std")]
 use std::time::Duration;
-use mavlink::error::MessageReadError;
 
 #[cfg(not(feature = "std"))]
 fn main() {}

--- a/src/bin/mavlink-dump.rs
+++ b/src/bin/mavlink-dump.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::thread;
 #[cfg(feature = "std")]
 use std::time::Duration;
+use mavlink::error::MessageReadError;
 
 #[cfg(not(feature = "std"))]
 fn main() {}
@@ -51,7 +52,7 @@ fn main() {
             Ok((_header, msg)) => {
                 println!("received: {:?}", msg);
             }
-            Err(e) => {
+            Err(MessageReadError::Io(e)) => {
                 match e.kind() {
                     std::io::ErrorKind::WouldBlock => {
                         //no messages currently available to receive -- wait a while
@@ -64,6 +65,8 @@ fn main() {
                     }
                 }
             }
+            // messages that didn't get through due to parser errors are ignored
+            _ => {}
         }
     }
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -18,7 +18,7 @@ pub trait MavConnection<M: Message> {
     /// Receive a mavlink message.
     ///
     /// Blocks until a valid frame is received, ignoring invalid messages.
-    fn recv(&self) -> io::Result<(MavHeader, M)>;
+    fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
 
     /// Send a mavlink message
     fn send(&self, header: &MavHeader, data: &M) -> io::Result<()>;
@@ -32,7 +32,7 @@ pub trait MavConnection<M: Message> {
     }
 
     /// Read whole frame
-    fn recv_frame(&self) -> io::Result<MavFrame<M>> {
+    fn recv_frame(&self) -> Result<MavFrame<M>, crate::error::MessageReadError> {
         let (header, msg) = self.recv()?;
         let protocol_version = self.get_protocol_version();
         Ok(MavFrame {

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -87,7 +87,7 @@ struct TcpWrite {
 }
 
 impl<M: Message> MavConnection<M> for TcpConnection {
-    fn recv(&self) -> io::Result<(MavHeader, M)> {
+    fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
         let mut lock = self.reader.lock().expect("tcp read failure");
         read_versioned_msg(&mut *lock, self.protocol_version)
     }

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -140,7 +140,7 @@ impl UdpConnection {
 }
 
 impl<M: Message> MavConnection<M> for UdpConnection {
-    fn recv(&self) -> io::Result<(MavHeader, M)> {
+    fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
         let mut guard = self.reader.lock().unwrap();
         let state = &mut *guard;
         loop {
@@ -153,8 +153,9 @@ impl<M: Message> MavConnection<M> for UdpConnection {
                 }
             }
 
-            if let Ok((h, m)) = read_versioned_msg(&mut state.recv_buf, self.protocol_version) {
-                return Ok((h, m));
+            match read_versioned_msg(&mut state.recv_buf, self.protocol_version) {
+                ok @ Ok(..) => return ok,
+                _ => (),
             }
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,60 @@
+use std::error::Error;
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug)]
+pub enum ParserError {
+    InvalidFlag { flag_type: String, value: u32 },
+    InvalidEnum { enum_type: String, value: u32 },
+    UnknownMessage { id: u32 },
+}
+
+impl Display for ParserError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParserError::InvalidFlag { flag_type, value } => write!(
+                f,
+                "Invalid flag value for flag type {:?}, got {:?}",
+                flag_type, value
+            ),
+            ParserError::InvalidEnum { enum_type, value } => write!(
+                f,
+                "Invalid enum value for enum type {:?}, got {:?}",
+                enum_type, value
+            ),
+            ParserError::UnknownMessage { id } => {
+                write!(f, "Unknown message with ID {:?}", id)
+            }
+        }
+    }
+}
+
+impl Error for ParserError {}
+
+#[derive(Debug)]
+pub enum MessageReadError {
+    Io(std::io::Error),
+    Parse(ParserError),
+}
+
+impl Display for MessageReadError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "Failed to read message: {:#?}", e),
+            Self::Parse(e) => write!(f, "Failed to read message: {:#?}", e),
+        }
+    }
+}
+
+impl Error for MessageReadError {}
+
+impl From<std::io::Error> for MessageReadError {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<ParserError> for MessageReadError {
+    fn from(e: ParserError) -> Self {
+        Self::Parse(e)
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,9 +21,7 @@ impl Display for ParserError {
                 "Invalid enum value for enum type {:?}, got {:?}",
                 enum_type, value
             ),
-            ParserError::UnknownMessage { id } => {
-                write!(f, "Unknown message with ID {:?}", id)
-            }
+            ParserError::UnknownMessage { id } => write!(f, "Unknown message with ID {:?}", id),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,10 @@
 #[cfg(not(feature = "std"))]
 extern crate alloc;
 
+use core::result::Result;
+
 #[cfg(feature = "std")]
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 #[cfg(feature = "std")]
 extern crate byteorder;
@@ -42,6 +44,7 @@ use serde::{Deserialize, Serialize};
 
 extern crate bytes;
 use bytes::{Buf, Bytes, IntoBuf};
+use crate::error::{ParserError};
 
 extern crate bitflags;
 extern crate num_derive;
@@ -50,16 +53,24 @@ extern crate num_traits;
 // include generate definitions
 include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 
+pub mod error;
+
 pub trait Message
 where
     Self: Sized,
 {
     fn message_id(&self) -> u32;
-    fn message_id_from_name(name: &str) -> std::result::Result<u32, &'static str>;
-    fn default_message_from_id(id: u32) -> std::result::Result<Self, &'static str>;
     fn ser(&self) -> Vec<u8>;
+
+    fn parse(
+        version: MavlinkVersion,
+        msgid: u32,
+        payload: &[u8],
+    ) -> Result<Self, error::ParserError>;
+
+    fn message_id_from_name(name: &str) -> Result<u32, &'static str>;
+    fn default_message_from_id(id: u32) -> Result<Self, &'static str>;
     fn extra_crc(id: u32) -> u8;
-    fn parse(version: MavlinkVersion, msgid: u32, payload: &[u8]) -> Option<Self>;
 }
 
 /// Metadata from a MAVLink packet header
@@ -145,7 +156,7 @@ impl<M: Message> MavFrame<M> {
     }
 
     /// Deserialize MavFrame from a slice that has been received from, for example, a socket.
-    pub fn deser(version: MavlinkVersion, input: &[u8]) -> Option<Self> {
+    pub fn deser(version: MavlinkVersion, input: &[u8]) -> Result<Self, ParserError> {
         let mut buf = Bytes::from(input).into_buf();
 
         let system_id = buf.get_u8();
@@ -162,14 +173,13 @@ impl<M: Message> MavFrame<M> {
             MavlinkVersion::V1 => buf.get_u8() as u32,
         };
 
-        if let Some(msg) = M::parse(version, msg_id, &buf.collect::<Vec<u8>>()) {
-            Some(MavFrame {
+        match M::parse(version, msg_id, &buf.collect::<Vec<u8>>()) {
+            Ok(msg) => Ok(MavFrame {
                 header,
                 msg,
                 protocol_version: version,
-            })
-        } else {
-            None
+            }),
+            Err(err) => Err(err)
         }
     }
 
@@ -182,7 +192,7 @@ impl<M: Message> MavFrame<M> {
 pub fn read_versioned_msg<M: Message, R: Read>(
     r: &mut R,
     version: MavlinkVersion,
-) -> Result<(MavHeader, M)> {
+) -> Result<(MavHeader, M), error::MessageReadError> {
     match version {
         MavlinkVersion::V2 => read_v2_msg(r),
         MavlinkVersion::V1 => read_v1_msg(r),
@@ -190,7 +200,9 @@ pub fn read_versioned_msg<M: Message, R: Read>(
 }
 
 /// Read a MAVLink v1  message from a Read stream.
-pub fn read_v1_msg<M: Message, R: Read>(r: &mut R) -> Result<(MavHeader, M)> {
+pub fn read_v1_msg<M: Message, R: Read>(
+    r: &mut R,
+) -> Result<(MavHeader, M), error::MessageReadError> {
     loop {
         if r.read_u8()? != MAV_STX {
             continue;
@@ -219,23 +231,27 @@ pub fn read_v1_msg<M: Message, R: Read>(r: &mut R) -> Result<(MavHeader, M)> {
             continue;
         }
 
-        if let Some(msg) = M::parse(MavlinkVersion::V1, msgid.into(), payload) {
-            return Ok((
-                MavHeader {
-                    sequence: seq,
-                    system_id: sysid,
-                    component_id: compid,
-                },
-                msg,
-            ));
-        }
+        return M::parse(MavlinkVersion::V1, msgid as u32, payload)
+            .map(|msg| {
+                (
+                    MavHeader {
+                        sequence: seq,
+                        system_id: sysid,
+                        component_id: compid,
+                    },
+                    msg,
+                )
+            })
+            .map_err(|err| err.into());
     }
 }
 
 const MAVLINK_IFLAG_SIGNED: u8 = 0x01;
 
 /// Read a MAVLink v2  message from a Read stream.
-pub fn read_v2_msg<M: Message, R: Read>(r: &mut R) -> Result<(MavHeader, M)> {
+pub fn read_v2_msg<M: Message, R: Read>(
+    r: &mut R,
+) -> Result<(MavHeader, M), error::MessageReadError> {
     loop {
         // search for the magic framing value indicating start of mavlink message
         if r.read_u8()? != MAV_STX_V2 {
@@ -305,21 +321,18 @@ pub fn read_v2_msg<M: Message, R: Read>(r: &mut R) -> Result<(MavHeader, M)> {
             continue;
         }
 
-        if let Some(msg) = M::parse(MavlinkVersion::V2, msgid, payload) {
-            return Ok((
-                MavHeader {
-                    sequence: seq,
-                    system_id: sysid,
-                    component_id: compid,
-                },
-                msg,
-            ));
-        } else {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Invalid MavMessage",
-            ));
-        }
+        return M::parse(MavlinkVersion::V2, msgid, payload)
+            .map(|msg| {
+                (
+                    MavHeader {
+                        sequence: seq,
+                        system_id: sysid,
+                        component_id: compid,
+                    },
+                    msg,
+                )
+            })
+            .map_err(|err| err.into());
     }
 }
 
@@ -329,7 +342,7 @@ pub fn write_versioned_msg<M: Message, W: Write>(
     version: MavlinkVersion,
     header: MavHeader,
     data: &M,
-) -> Result<()> {
+) -> std::io::Result<()> {
     match version {
         MavlinkVersion::V2 => write_v2_msg(w, header, data),
         MavlinkVersion::V1 => write_v1_msg(w, header, data),
@@ -337,7 +350,11 @@ pub fn write_versioned_msg<M: Message, W: Write>(
 }
 
 /// Write a MAVLink v2 message to a Write stream.
-pub fn write_v2_msg<M: Message, W: Write>(w: &mut W, header: MavHeader, data: &M) -> Result<()> {
+pub fn write_v2_msg<M: Message, W: Write>(
+    w: &mut W,
+    header: MavHeader,
+    data: &M,
+) -> std::io::Result<()> {
     let msgid = data.message_id();
     let payload = data.ser();
     //    println!("write payload_len : {}", payload.len());
@@ -375,7 +392,11 @@ pub fn write_v2_msg<M: Message, W: Write>(w: &mut W, header: MavHeader, data: &M
 }
 
 /// Write a MAVLink v1 message to a Write stream.
-pub fn write_v1_msg<M: Message, W: Write>(w: &mut W, header: MavHeader, data: &M) -> Result<()> {
+pub fn write_v1_msg<M: Message, W: Write>(
+    w: &mut W,
+    header: MavHeader,
+    data: &M,
+) -> std::io::Result<()> {
     let msgid = data.message_id();
     let payload = data.ser();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ pub use self::connection::{connect, MavConnection};
 use serde::{Deserialize, Serialize};
 
 extern crate bytes;
+use crate::error::ParserError;
 use bytes::{Buf, Bytes, IntoBuf};
-use crate::error::{ParserError};
 
 extern crate bitflags;
 extern crate num_derive;
@@ -179,7 +179,7 @@ impl<M: Message> MavFrame<M> {
                 msg,
                 protocol_version: version,
             }),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         }
     }
 


### PR DESCRIPTION
Resolves #37. All of the functions that involve parsing a `MavMessage` will now return a `Result<Message, MessageReadError>` instead of panicking upon encountering invalid data.