### PR TITLE
Use crc-any over crc16 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "mavlink"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["Todd Stellanova", "Michal Podhradsky", "Kevin Mehall", "Tim Ryan", "Patrick José Pereira", "Ibiyemi Abiodun"]
 build = "build/main.rs"
 description = "Implements the MAVLink data interchange format for UAVs."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/mavlink/rust-mavlink"
 edition = "2018"
 
 [build-dependencies]
-crc16 = "0.3.3"
+crc-any = "2.3.0"
 bytes = "0.4"
 xml-rs = "0.2"
 quote = "0.3"
@@ -23,7 +23,7 @@ name = "mavlink-dump"
 required-features = ["common"]
 
 [dependencies]
-crc16 = "0.3.3"
+crc-any = "2.3.0"
 bytes = "0.4"
 num-traits = "0.2"
 num-derive = "0.2"

--- a/build/main.rs
+++ b/build/main.rs
@@ -2,7 +2,6 @@
 #[macro_use]
 extern crate quote;
 
-extern crate crc16;
 extern crate xml;
 
 mod binder;


### PR DESCRIPTION
crc-any is maintained and more popular over crc16
This also fix a problem where rust-mavlink needs to recompiled
every single time

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>