### PR TITLE
Add support for embedded, no_std environments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Check Type
       run: cargo fmt -- --check
     - name: Run internal tests
-      run: cargo test --verbose --all-features -- --nocapture
+      run: cargo test --verbose --features all-dialects -- --nocapture
 
   build:
     needs: quick-tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,18 +26,28 @@ jobs:
         include:
         - os: macos-latest
           TARGET: x86_64-apple-darwin
+          FEATURES: --features all-dialects
 
         - os: ubuntu-latest
           TARGET: arm-unknown-linux-musleabihf
+          FLAGS: --features ardupilotmega
 
         - os: ubuntu-latest
           TARGET: armv7-unknown-linux-musleabihf
+          FLAGS: --features ardupilotmega
 
         - os: ubuntu-latest
           TARGET: x86_64-unknown-linux-musl
+          FLAGS: --features all-dialects
+
+        - os: ubuntu-latest
+          TARGET: thumbv7m-none-eabi
+          FLAGS: --no-default-features --features embedded
 
         - os: windows-latest
           TARGET: x86_64-pc-windows-msvc
+          FLAGS: --features all-dialects
+
     steps:
     - name: Building ${{ matrix.TARGET }}
       run: echo "${{ matrix.TARGET }}"
@@ -51,4 +61,4 @@ jobs:
       with:
         use-cross: true
         command: build
-        args: --verbose --release --target=${{ matrix.TARGET }}
+        args: --verbose --release --target=${{ matrix.TARGET }} ${{ matrix.FLAGS }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [build-dependencies]
 crc-any = "2.3.0"
-bytes = "0.4"
+bytes = { version = "1.0", default-features = false }
 xml-rs = "0.2"
 quote = "0.3"
 lazy_static = "1.2.0"
@@ -24,13 +24,15 @@ required-features = ["ardupilotmega"]
 
 [dependencies]
 crc-any = "2.3.5"
-bytes = "0.4"
-num-traits = "0.2"
+bytes = { version = "1.0", default-features = false }
+num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3.2"
 bitflags = "1.2.1"
 serial = { version = "0.4", optional = true }
 serde = { version = "1.0.115", optional = true }
-byteorder = { version = "1.3.4", optional = true }
+byteorder = { version = "1.3.4", default-features = false }
+embedded-hal = { version = "0.2", optional = true }
+nb = { version = "0.1", optional = true }
 
 [features]
 "ardupilotmega" = ["common", "icarous", "uavionix"]
@@ -50,10 +52,11 @@ byteorder = { version = "1.3.4", optional = true }
 
 "emit-description" = []
 "emit-extensions" = []
-"std" = ["byteorder"]
+"std" = ["byteorder/std"]
 "udp" = []
 "tcp" = []
 "direct-serial" = []
+"embedded" = ["embedded-hal", "nb"]
 default= ["std", "tcp", "udp", "direct-serial", "serial", "serde", "common"]
 
 # build with all features on docs.rs so that users viewing documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,23 @@ nb = { version = "0.1", optional = true }
 "icarous" = []
 "common" = []
 
+"all-dialects" = [
+    "ardupilotmega",
+    "asluav",
+    "autoquad",
+    "matrixpilot",
+    "minimal",
+    "paparazzi",
+    "python_array_test",
+    "slugs",
+    "standard",
+    "test",
+    "ualberta",
+    "uavionix",
+    "icarous",
+    "common",
+]
+
 "emit-description" = []
 "emit-extensions" = []
 "std" = ["byteorder/std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,4 +79,4 @@ default= ["std", "tcp", "udp", "direct-serial", "serial", "serde", "common"]
 # build with all features on docs.rs so that users viewing documentation
 # can see everything
 [package.metadata.docs.rs]
-all-features = true
+features = ["default", "all-dialects"]

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -156,7 +156,7 @@ impl MavProfile {
         quote! {
             #comment
             #[allow(unused_imports)]
-            use bytes::{Buf, BufMut, Bytes, IntoBuf};
+            use bytes::{Buf, BufMut, Bytes, BytesMut};
             #[allow(unused_imports)]
             use num_derive::FromPrimitive;
             #[allow(unused_imports)]
@@ -177,6 +177,9 @@ impl MavProfile {
 
             #[cfg(not(feature = "std"))]
             use alloc::vec::Vec;
+
+            #[cfg(not(feature = "std"))]
+            use alloc::string::ToString;
 
             #(#enums)*
 
@@ -556,14 +559,14 @@ impl MavMessage {
                 let avail_len = _input.len();
 
                 // fast zero copy
-                let mut buf = Bytes::from(_input).into_buf();
+                let mut buf = BytesMut::from(_input);
 
                 // handle payload length truncuation due to empty fields
                 if avail_len < #encoded_len_name {
                     //copy available bytes into an oversized buffer filled with zeros
                     let mut payload_buf  = [0; #encoded_len_name];
                     payload_buf[0..avail_len].copy_from_slice(_input);
-                    buf = Bytes::from(&payload_buf[..]).into_buf();
+                    buf = BytesMut::from(&payload_buf[..]);
                 }
 
                 let mut _struct = Self::default();

--- a/src/connection/direct_serial.rs
+++ b/src/connection/direct_serial.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 
 //TODO why is this import so hairy?
 use crate::connection::direct_serial::serial::prelude::*;
-use crate::error::MessageReadError;
+use crate::error::{MessageReadError, MessageWriteError};
 
 /// Serial MAVLINK connection
 
@@ -74,7 +74,7 @@ impl<M: Message> MavConnection<M> for SerialConnection {
         }
     }
 
-    fn send(&self, header: &MavHeader, data: &M) -> io::Result<()> {
+    fn send(&self, header: &MavHeader, data: &M) -> Result<(), MessageWriteError> {
         let mut port = self.port.lock().unwrap();
         let mut sequence = self.sequence.lock().unwrap();
 

--- a/src/connection/file.rs
+++ b/src/connection/file.rs
@@ -1,5 +1,5 @@
 use crate::connection::MavConnection;
-use crate::error::MessageReadError;
+use crate::error::{MessageReadError, MessageWriteError};
 use crate::{read_versioned_msg, MavHeader, MavlinkVersion, Message};
 use std::fs::File;
 use std::io::{self};
@@ -45,7 +45,7 @@ impl<M: Message> MavConnection<M> for FileConnection {
         }
     }
 
-    fn send(&self, _header: &MavHeader, _data: &M) -> io::Result<()> {
+    fn send(&self, _header: &MavHeader, _data: &M) -> Result<(), MessageWriteError> {
         Ok(())
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -21,13 +21,13 @@ pub trait MavConnection<M: Message> {
     fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
 
     /// Send a mavlink message
-    fn send(&self, header: &MavHeader, data: &M) -> io::Result<()>;
+    fn send(&self, header: &MavHeader, data: &M) -> Result<(), crate::error::MessageWriteError>;
 
     fn set_protocol_version(&mut self, version: MavlinkVersion);
     fn get_protocol_version(&self) -> MavlinkVersion;
 
     /// Write whole frame
-    fn send_frame(&self, frame: &MavFrame<M>) -> io::Result<()> {
+    fn send_frame(&self, frame: &MavFrame<M>) -> Result<(), crate::error::MessageWriteError> {
         self.send(&frame.header, &frame.msg)
     }
 
@@ -43,7 +43,7 @@ pub trait MavConnection<M: Message> {
     }
 
     /// Send a message with default header
-    fn send_default(&self, data: &M) -> io::Result<()> {
+    fn send_default(&self, data: &M) -> Result<(), crate::error::MessageWriteError> {
         let header = MavHeader::default();
         self.send(&header, data)
     }

--- a/src/connection/tcp.rs
+++ b/src/connection/tcp.rs
@@ -92,7 +92,7 @@ impl<M: Message> MavConnection<M> for TcpConnection {
         read_versioned_msg(&mut *lock, self.protocol_version)
     }
 
-    fn send(&self, header: &MavHeader, data: &M) -> io::Result<()> {
+    fn send(&self, header: &MavHeader, data: &M) -> Result<(), crate::error::MessageWriteError> {
         let mut lock = self.writer.lock().unwrap();
 
         let header = MavHeader {

--- a/src/connection/udp.rs
+++ b/src/connection/udp.rs
@@ -160,7 +160,7 @@ impl<M: Message> MavConnection<M> for UdpConnection {
         }
     }
 
-    fn send(&self, header: &MavHeader, data: &M) -> io::Result<()> {
+    fn send(&self, header: &MavHeader, data: &M) -> Result<(), crate::error::MessageWriteError> {
         let mut guard = self.writer.lock().unwrap();
         let state = &mut *guard;
 

--- a/src/embedded.rs
+++ b/src/embedded.rs
@@ -1,0 +1,49 @@
+use byteorder::ByteOrder;
+
+use crate::error::*;
+
+/// Replacement for std::io::Read + byteorder::ReadBytesExt in no_std envs
+pub trait Read {
+    fn read_u8(&mut self) -> Result<u8, MessageReadError>;
+
+    fn read_u16<B: ByteOrder>(&mut self) -> Result<u16, MessageReadError> {
+        let mut buffer = [0; 2];
+        self.read_exact(&mut buffer)?;
+        Ok(B::read_u16(&buffer))
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), MessageReadError> {
+        for i in 0..buf.len() {
+            buf[i] = self.read_u8()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<R: embedded_hal::serial::Read<u8>> Read for R {
+    fn read_u8(&mut self) -> Result<u8, MessageReadError> {
+        nb::block!(self.read()).map_err(|_| MessageReadError::Io)
+    }
+}
+
+/// Replacement for std::io::Write + byteorder::WriteBytesExt in no_std envs
+pub trait Write {
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), MessageWriteError>;
+
+    fn write_u16<B: ByteOrder>(&mut self, n: u16) -> Result<(), MessageWriteError> {
+        let mut buffer = [0; 2];
+        B::write_u16(&mut buffer, n);
+        self.write_all(&buffer)
+    }
+}
+
+impl<W: embedded_hal::serial::Write<u8>> Write for W {
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), MessageWriteError> {
+        for i in 0..buf.len() {
+            nb::block!(self.write(buf[i])).map_err(|_| MessageWriteError::Io)?;
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
I needed to use this crate on an STM32F4, so I tweaked the crate to compile without `std`, and added support for the `serial::Read<u8>` and `serial::Write<u8>` traits from `embedded-hal`. I tried to make as few changes to the existing code as possible, so the `std` development is not inconvenienced unnecessarily, however, some changes could not be avoided.

Overview of the changes:
- Updated the `bytes` dependency to 1.0. This allows using it in `no_std` environments, but it did require replacing `Bytes::from(x).into_buf()` with `BytesMut::from(x)` and explicitly converting them to an iterator for collecting them into a `Vec`.
- Enabled the `byteorder` crate for all features, and only enabled the `std` feature of the crate for this crates `std` feature. This means `LittleEndian` and its `ByteOrder` trait are available on `no_std`, but `{ReadBytesExt, WriteBytesExt}` are not.
- Added a feature `embedded`, which enables two additional trait, which replace `std::io::{Read, Write}` (and the corresponding extensions from the `byteorder` crate) and implement the methods required.
- Changed the `write_x_message` methods to return results with a new error type `MessageWriteError` (analogous to `MessageReadError`). This was necessary, because `std::io::Error`s are obviously not available without `std`. For the read methods, I solved this by simply replacing the `Io` enum variant with one without an inner error (since the Error type for `embedded_hal::serial::{Read,Write}` is implementation-specific). This should be the only non-backwards-compatible change.
- Changed the methods in the connection trait accordingly.

I did not implement a connection for embedded serial ports yet. That connection would probably involve boxed traits for `Read<u8>` and `Write<u8>`.

Also, actually using this on an STM32F4 requires nightly rust because of the allocator, and to actually get it on the thing required compiling with size optimizations (`opt-level = "z"`).

<details>
  <summary>A working example on an STM32F411 ("black pill") with an ArduPilot connected:</summary>

```rust
#![no_main]
#![no_std]
#![feature(alloc_error_handler)]
#![feature(default_alloc_error_handler)]

use core::panic::PanicInfo;
use alloc_cortex_m::CortexMHeap;
use rtt_target::{rtt_init_print, rprintln};

use embedded_hal::serial::Write;
use mavlink::*;

use cortex_m;
use stm32f4xx_hal as hal;
use hal::{prelude::*, stm32};
use hal::serial::Serial;
use hal::serial::config::Config;

// Needed for alloc in rust-mavlink
#[global_allocator]
static ALLOCATOR: CortexMHeap = CortexMHeap::empty();

fn request_data_stream<W: Write<u8>>(
    target: &mut W,
    seq: &mut u8,
    stream: u8,
    freq: u16,
    startstop: u8
) -> Result<(), error::MessageWriteError> {
    let request = ardupilotmega::MavMessage::common({
        common::MavMessage::REQUEST_DATA_STREAM(
            common::REQUEST_DATA_STREAM_DATA {
                target_system: 1,
                target_component: 0,
                req_stream_id: stream,
                req_message_rate: freq,
                start_stop: startstop,
            },
        )
    });

    let header = MavHeader {
        system_id: 0xff,
        component_id: 0xbe,
        sequence: *seq,
    };

    *seq = seq.wrapping_add(1);

    write_versioned_msg::<ardupilotmega::MavMessage, _>(
        target,
        MavlinkVersion::V1,
        header,
        &request
    )
}

#[cortex_m_rt::entry]
fn main() -> ! {
    rtt_init_print!();
    rprintln!("RTT init");

    let dp = stm32::Peripherals::take().unwrap();
    let mut cp = cortex_m::peripheral::Peripherals::take().unwrap();

    cp.DWT.enable_cycle_counter();

    let gpioa = dp.GPIOA.split();

    // Configure clock to use 25MHz external oscillator and set PLL to 4x to
    // reach the maximum clock speed of 100MHz.
    let rcc = dp.RCC.constrain();
    let clocks = rcc.cfgr
        .use_hse(25.mhz())
        .sysclk(100.mhz())
        .freeze();

    // Initialize Heap
    let start = cortex_m_rt::heap_start() as usize;
    let size = 1024;
    unsafe { ALLOCATOR.init(start, size) }

    // Initialize MavLink serial port
    let tx = gpioa.pa9.into_alternate_af7();
    let rx = gpioa.pa10.into_alternate_af7();
    let serial = Serial::usart1(
        dp.USART1,
        (tx, rx),
        Config::default().baudrate(57600.bps()),
        clocks
    ).unwrap();
    let (mut mavlink_tx, mut mavlink_rx) = serial.split();

    let mut requested_data_streams = false;
    let mut seq_tx = 0;

    loop {
        match read_versioned_msg::<ardupilotmega::MavMessage, _>(&mut mavlink_rx, MavlinkVersion::V1) {
            Ok((_header, msg)) => {
                rprintln!("{:?}", msg);

                match msg {
                    ardupilotmega::MavMessage::common(common::MavMessage::HEARTBEAT(_data)) => {
                        if !requested_data_streams {
                            request_data_stream(&mut mavlink_tx, &mut seq_tx, 0, 0, 0); // disable all
                            request_data_stream(&mut mavlink_tx, &mut seq_tx, 10, 10, 1); // enable EXTRA1 (10 Hz)
                            requested_data_streams = true;
                        }
                    },
                    ardupilotmega::MavMessage::common(common::MavMessage::ATTITUDE(data)) => {
                        rprintln!("{:?}", data.pitch);
                    },
                    _ => {
                    }
                }
            },
            Err(e) => {
                rprintln!("error: {:?}", e);
            }
        }
    }
}

#[inline(never)]
#[panic_handler]
fn panic(info: &PanicInfo) -> ! {
    rprintln!("{}", info);
    loop {} // You might need a compiler fence in here.
}

```
</details>

I'm not sure if this is ready to be merged in its current state, but I figured I'd create a PR for input and discussion. I have also not been able to properly test the non-embedded version with these changes, but the example still compiles.