### PR TITLE
Fix rust analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+src/generated
 target
 Cargo.lock

--- a/build/main.rs
+++ b/build/main.rs
@@ -54,7 +54,18 @@ pub fn main() {
     let mut definitions_dir = src_dir.to_path_buf();
     definitions_dir.push("mavlink/message_definitions/v1.0");
 
-    let out_dir = env::var("OUT_DIR").unwrap();
+    // We generate the files under a path that does not depends of cargo
+    // env variables. The reason behind this is that such variables depends of
+    // a number of variables, such as: plataform, target and etc, making impossible
+    // for cargo to provide such information for tools such as rust-analyzer,
+    // turning the development of Rust MAVLink much harder for any user.
+    let cargo_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let out_dir = Path::new(&cargo_dir).join("src/generated");
+    if !out_dir.exists() {
+        std::fs::create_dir(&out_dir).unwrap_or_else(|error| {
+            panic!("Failed to created generated folder: {:#?}", error);
+        });
+    }
 
     let mut modules = vec![];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ extern crate num_traits;
 use crc_any::CRCu16;
 
 // include generate definitions
-include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+include!(concat!("generated/mod.rs"));
 
 pub mod error;
 


### PR DESCRIPTION
A couple of developers including myself finds it much harder to code with rust-mavlink without autocomplete provided by the official tool rust-analyzer.
This patches avoid a problem where the generated files / includes depends of cargo environment variables to be find, since cargo does not provide such variables, since they are only available during compilation time, this patch moves the generated files under a know folder.