### PR TITLE
Moves rust-mavlink to move from serial to serialport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytes = { version = "1.0", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.3.2"
 bitflags = "1.2.1"
-serial = { version = "0.4", optional = true }
+serialport = { version = "4.0", optional = true }
 serde = { version = "1.0.115", optional = true }
 byteorder = { version = "1.3.4", default-features = false }
 embedded-hal = { version = "0.2", optional = true }
@@ -74,7 +74,7 @@ nb = { version = "0.1", optional = true }
 "tcp" = []
 "direct-serial" = []
 "embedded" = ["embedded-hal", "nb"]
-default= ["std", "tcp", "udp", "direct-serial", "serial", "serde", "common"]
+default= ["std", "tcp", "udp", "direct-serial", "serialport", "serde", "common"]
 
 # build with all features on docs.rs so that users viewing documentation
 # can see everything

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ num-derive = "0.3.2"
 bitflags = "1.2.1"
 serialport = { version = "4.0", optional = true }
 serde = { version = "1.0.115", optional = true }
-byteorder = { version = "1.3.4", default-features = false }
+byteorder = { version = "1.4.3", default-features = false }
 embedded-hal = { version = "0.2", optional = true }
 nb = { version = "0.1", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,9 +399,8 @@ pub fn write_v2_msg<M: Message, W: Write>(
 
     let len = payload.len() + header.len() + crc_bytes.len();
 
-    w.write_all(header)?;
-    w.write_all(&payload[..])?;
-    w.write_all(&crc_bytes)?;
+    w.write_all(&[header, &payload[..], &crc_bytes].concat())?;
+    w.flush()?;
 
     Ok(len)
 }


### PR DESCRIPTION
The main idea of this patch is to allow read and write in parallel when using serial port, as UDP and TCP methods already provide, serialport library has a full duplex implementation of the serial access to allow such thing. 