### PR TITLE
Use u8 instead of chars in Rust

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -873,7 +873,7 @@ impl MavType {
     pub fn rust_reader(&self, val: Ident, buf: Ident) -> Tokens {
         use self::MavType::*;
         match self.clone() {
-            Char => quote! {#val = #buf.get_u8() as char;},
+            Char => quote! {#val = #buf.get_u8();},
             UInt8 => quote! {#val = #buf.get_u8();},
             UInt16 => quote! {#val = #buf.get_u16_le();},
             UInt32 => quote! {#val = #buf.get_u32_le();},
@@ -915,7 +915,7 @@ impl MavType {
         match self.clone() {
             UInt8MavlinkVersion => quote! {#buf.put_u8(#val);},
             UInt8 => quote! {#buf.put_u8(#val);},
-            Char => quote! {#buf.put_u8(#val as u8);},
+            Char => quote! {#buf.put_u8(#val);},
             UInt16 => quote! {#buf.put_u16_le(#val);},
             UInt32 => quote! {#buf.put_u32_le(#val);},
             Int8 => quote! {#buf.put_i8(#val);},
@@ -987,7 +987,7 @@ impl MavType {
         match self.clone() {
             UInt8 | UInt8MavlinkVersion => "u8".into(),
             Int8 => "i8".into(),
-            Char => "char".into(),
+            Char => "u8".into(),
             UInt16 => "u16".into(),
             Int16 => "i16".into(),
             UInt32 => "u32".into(),


### PR DESCRIPTION
This change will cause structures to fill less in memory since the
`char` type in rust is actually a unicode scalar value and is 4 bytes
large[^1] compared to C where a c where it is most often a single
byte.

[^1]: `std::mem::size_of::<char>() = 4`