### PR TITLE
Truncate MAVLink 2 messages

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -425,10 +425,10 @@ impl MavProfile {
         includes: &Vec<Ident>,
     ) -> TokenStream {
         quote! {
-            fn ser(&self) -> Vec<u8> {
+            fn ser(&self, version: MavlinkVersion) -> Vec<u8> {
                 match self {
-                    #(&MavMessage::#enums(ref body) => body.ser(),)*
-                    #(&MavMessage::#includes(ref msg) => msg.ser(),)*
+                    #(&MavMessage::#enums(ref body) => body.ser(version),)*
+                    #(&MavMessage::#includes(ref msg) => msg.ser(version),)*
                 }
             }
         }
@@ -630,6 +630,9 @@ impl MavMessage {
         quote! {
             let mut _tmp = Vec::new();
             #(#ser_vars)*
+            if matches!(version, MavlinkVersion::V2) {
+                crate::remove_trailing_zeroes(&mut _tmp);
+            }
             _tmp
         }
     }
@@ -699,7 +702,7 @@ impl MavMessage {
                     #deser_vars
                 }
 
-                pub fn ser(&self) -> Vec<u8> {
+                pub fn ser(&self, version: MavlinkVersion) -> Vec<u8> {
                     #serialize_vars
                 }
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,18 @@
+#[cfg(not(feature = "std"))]
+use alloc::vec::Vec;
+
+/// Removes the trailing zeroes in the payload
+///
+/// # Note:
+///
+/// There must always be at least one remaining byte even if it is a
+/// zero byte.
+#[allow(dead_code)]
+pub(crate) fn remove_trailing_zeroes(buf: &mut Vec<u8>) {
+    while let Some(&0) = buf.last() {
+        if buf.len() <= 1 {
+            break;
+        }
+        buf.pop();
+    }
+}


### PR DESCRIPTION
The MAVLink documentation states the following[^1]:
> *MAVLink 2* implementations *must* truncate any empty (zero-filled)
> bytes at the end of the serialized payload before it is sent.

So this PR implements that.

[^1]: https://mavlink.io/en/guide/serialization.html#payload_truncation