### PR TITLE
Use quick-xml instead of xml-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 [build-dependencies]
 crc-any = "2.3.0"
 bytes = { version = "1.0", default-features = false }
-xml-rs = "0.2"
+quick-xml = "0.23"
 quote = "0.3"
 lazy_static = "1.2.0"
 serde = { version = "1.0.115", optional = true, features = ["derive"] }

--- a/build/main.rs
+++ b/build/main.rs
@@ -2,7 +2,7 @@
 #[macro_use]
 extern crate quote;
 
-extern crate xml;
+extern crate quick_xml;
 
 mod binder;
 mod parser;


### PR DESCRIPTION
Since XML-rs is for the time being unmaintained[^1], and have been
marked as such in RUSTSEC[^2]. I have ported the XML parsing to
quick-xml.

Supersedes #107 

[^1]: https://github.com/netvl/xml-rs/issues/221

[^2]: https://rustsec.org/advisories/RUSTSEC-2022-0048