### PR TITLE
Update mavlink submodule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ nb = { version = "1.0", optional = true }
 "ualberta" = ["common"]
 "uavionix" = ["common"]
 "icarous" = []
-"common" = []
+"common" = ["minimal"]
 
 "all-dialects" = [
     "ardupilotmega",

--- a/build/patches/esc_failure_flags.patch
+++ b/build/patches/esc_failure_flags.patch
@@ -1,0 +1,16 @@
+diff --git a/message_definitions/v1.0/common.xml b/message_definitions/v1.0/common.xml
+index 3f09450d..bbaf4067 100644
+--- a/message_definitions/v1.0/common.xml
++++ b/message_definitions/v1.0/common.xml
+@@ -6983,7 +6983,10 @@
+       <field type="uint8_t" name="count">Total number of ESCs in all messages of this type. Message fields with an index higher than this should be ignored because they contain invalid data.</field>
+       <field type="uint8_t" name="connection_type" enum="ESC_CONNECTION_TYPE">Connection type protocol for all ESC.</field>
+       <field type="uint8_t" name="info" display="bitmask">Information regarding online/offline status of each ESC.</field>
+-      <field type="uint16_t[4]" name="failure_flags" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flags.</field>
++      <field type="uint16_t" name="failure_flag_0" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flag for index 0.</field>
++      <field type="uint16_t" name="failure_flag_1" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flag for index 1.</field>
++      <field type="uint16_t" name="failure_flag_2" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flag for index 2.</field>
++      <field type="uint16_t" name="failure_flag_3" enum="ESC_FAILURE_FLAGS" display="bitmask">Bitmap of ESC failure flag for index 3.</field>
+       <field type="uint32_t[4]" name="error_count">Number of reported errors by each ESC since boot.</field>
+       <field type="int16_t[4]" name="temperature" units="cdegC" invalid="[INT16_MAX]">Temperature of each ESC. INT16_MAX: if data not supplied by ESC.</field>
+     </message>

--- a/src/bin/mavlink-dump.rs
+++ b/src/bin/mavlink-dump.rs
@@ -78,12 +78,12 @@ fn main() {
 /// and the function could return only a simple `mavlink::common::MavMessage` type
 #[cfg(feature = "std")]
 pub fn heartbeat_message() -> mavlink::common::MavMessage {
-    mavlink::common::MavMessage::HEARTBEAT(mavlink::common::HEARTBEAT_DATA {
+    mavlink::minimal::MavMessage::HEARTBEAT(mavlink::minimal::HEARTBEAT_DATA {
         custom_mode: 0,
-        mavtype: mavlink::common::MavType::MAV_TYPE_QUADROTOR,
-        autopilot: mavlink::common::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
-        base_mode: mavlink::common::MavModeFlag::empty(),
-        system_status: mavlink::common::MavState::MAV_STATE_STANDBY,
+        mavtype: mavlink::minimal::MavType::MAV_TYPE_QUADROTOR,
+        autopilot: mavlink::minimal::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+        base_mode: mavlink::minimal::MavModeFlag::empty(),
+        system_status: mavlink::minimal::MavState::MAV_STATE_STANDBY,
         mavlink_version: 0x3,
     })
 }


### PR DESCRIPTION
This patch updates the mavlink submodule and ads some fixes to make it work with the new definitions. 

I added a patch because the arrays of bit masks are quite annoying to support with the current way they are generated, I have asked what they think about it upstream or else we will just have to change it up. https://github.com/mavlink/mavlink/issues/1884 

The changes in #113 will probably make the changes in [src/bin/mavlink-dump.rs](https://github.com/mavlink/rust-mavlink/compare/master...fusion-engineering-forks:rust-mavlink:valdemar/update-mavlink-definitions#diff-82c9e68044b14e96c9dc03f4fa3d3d7da7c20e6bd2981c5b05e65bbdd49ca1b9) unnecessary if that is merged.