### PR TITLE
update clippy linting job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,14 @@ jobs:
       - uses: actions/checkout@master
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2022-11-30
+          toolchain: nightly-2022-12-01
           components: clippy
       - uses: giraffate/clippy-action@41d079cb4ab2466a07853dc78eefbbe4de373a2d
         with:
-          clippy_flags: --all-targets
-          reporter: github-pr-review
+          clippy_flags: --all-targets --features ardupilotmega
+          reporter: github-pr-check
           filter_mode: nofilter
+          fail_on_error: true
 
   internal-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,11 @@ jobs:
         with:
           toolchain: nightly-2022-11-30
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: giraffate/clippy-action@41d079cb4ab2466a07853dc78eefbbe4de373a2d
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all --all-targets
+          clippy_flags: --all-targets
+          reporter: github-pr-review
+          filter_mode: nofilter
 
   internal-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
the old action is unsupported. This one will add inline comments to PRs. pretty.

question - what feature set should be enabled when performing clippy linting?

i'd prefer for the clippy warnings not to be escalated to build failures, so I'll leave this as a draft until I have a resolution there - see https://github.com/giraffate/clippy-action/issues/23