### PR TITLE
Fix enum value generation

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -364,10 +364,6 @@ impl MavEnum {
         }
     }
 
-    fn has_enum_values(&self) -> bool {
-        self.entries.iter().all(|x| x.value.is_some())
-    }
-
     fn emit_defs(&self) -> Vec<TokenStream> {
         let mut cnt = 0isize;
         self.entries
@@ -386,12 +382,13 @@ impl MavEnum {
                 #[cfg(not(feature = "emit-description"))]
                 let description = quote!();
 
-                if !self.has_enum_values() {
-                    value = quote!(#cnt);
+                if enum_entry.value.is_none() {
                     cnt += 1;
+                    value = quote!(#cnt);
                 } else {
-                    let tmp =
-                        TokenStream::from_str(&enum_entry.value.unwrap().to_string()).unwrap();
+                    let tmp_value = enum_entry.value.unwrap();
+                    cnt = cnt.max(tmp_value as isize);
+                    let tmp = TokenStream::from_str(&tmp_value.to_string()).unwrap();
                     value = quote!(#tmp);
                 };
                 if self.bitfield.is_some() {


### PR DESCRIPTION
When there is no value in an enum definition, the generated code starts at 0 instead of 1, which conflicts with `pymavlink`.
For example:
```xml
<enum name="MAV_FOO_BAR_BAZ">
	<description>A description</description>
	<entry name="FOO"></entry>
	<entry name="BAR"></entry>
	<entry name="BAZ"></entry>
</enum>
```
would generate
```rust
pub enum MavFooBarBaz {
    MAV_FOO_BAR_BAZ_FOO = 0isize,
    MAV_FOO_BAR_BAZ_BAR = 1isize,
    MAV_FOO_BAR_BAZ_BAZ = 2isize,
}
```
instead of
```rust
pub enum MavFooBarBaz {
    MAV_FOO_BAR_BAZ_FOO = 1isize,
    MAV_FOO_BAR_BAZ_BAR = 2isize,
    MAV_FOO_BAR_BAZ_BAZ = 3isize,
}
```


Here is a [link](https://github.com/ArduPilot/pymavlink/blob/bf45f3aa95d90e5eaa2383c8dcc10a49bdf958db/generator/mavparse.py#L270-L274) on how `pymavlink` does it.
`pymavlink` stores the highest value for an enum during its generation. If a field does not have a value, it takes the highest value plus one. If a field does have a value, it takes it and updates the highest value.
The highest value is initialized at 0.