### PR TITLE
fix: correctly deserialize MavFrame

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,9 +172,9 @@ impl<M: Message> MavFrame<M> {
     pub fn deser(version: MavlinkVersion, input: &[u8]) -> Result<Self, ParserError> {
         let mut buf = Bytes::new(input);
 
+        let sequence = buf.get_u8();
         let system_id = buf.get_u8();
         let component_id = buf.get_u8();
-        let sequence = buf.get_u8();
         let header = MavHeader {
             system_id,
             component_id,
@@ -182,8 +182,8 @@ impl<M: Message> MavFrame<M> {
         };
 
         let msg_id = match version {
-            MavlinkVersion::V2 => buf.get_u32_le(),
-            MavlinkVersion::V1 => buf.get_u8().into(),
+            MavlinkVersion::V2 => buf.get_u24_le(),
+            MavlinkVersion::V1 => buf.get_u8() as u32,
         };
 
         match M::parse(version, msg_id, buf.remaining_bytes()) {

--- a/tests/mav_frame_tests.rs
+++ b/tests/mav_frame_tests.rs
@@ -1,0 +1,34 @@
+pub mod test_shared;
+
+mod mav_frame_tests {
+    // NOTE: No header
+    pub const HEARTBEAT_V2: &[u8] = &[
+        0xef, // seq 239
+        0x01, // sys ID
+        0x01, // comp ID
+        0x00, 0x00, 0x00, // msg ID
+        0x05, 0x00, 0x00, 0x00, 0x02, 0x03, 0x59, 0x03, 0x03, // payload
+        16, 240, // checksum
+    ];
+
+    #[test]
+    pub fn test_deser() {
+        use mavlink::{common::MavMessage, MavFrame, MavlinkVersion};
+        let frame = MavFrame::<MavMessage>::deser(MavlinkVersion::V2, HEARTBEAT_V2)
+            .expect("failed to parse message");
+
+        assert_eq!(frame.header, crate::test_shared::COMMON_MSG_HEADER);
+        let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
+
+        let msg = match frame.msg {
+            MavMessage::HEARTBEAT(msg) => msg,
+            _ => panic!("Decoded wrong message type"),
+        };
+        assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
+        assert_eq!(msg.mavtype, heartbeat_msg.mavtype);
+        assert_eq!(msg.autopilot, heartbeat_msg.autopilot);
+        assert_eq!(msg.base_mode, heartbeat_msg.base_mode);
+        assert_eq!(msg.system_status, heartbeat_msg.system_status);
+        assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
+    }
+}


### PR DESCRIPTION
This commit addresses two bugs present in the `MavFrame::deser` implementation. It parsed the sequence number after system and component ids, but should instead parse it before. Furthermore the implementation used the `get_u32_le` method to parse the message id in mavlink v2. However the MAVLink spec specifies that this field should have 3 bytes, not 4 (like `u32`).