### PR TITLE
refactor: remove heapless dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0.115", optional = true, features = ["derive"] }
 byteorder = { version = "1.3.4", default-features = false }
 embedded-hal = { version = "0.2", optional = true }
 nb = { version = "1.0", optional = true }
-heapless = "0.7"
+serde_arrays = { version = "0.1.0", optional = true }
 
 [features]
 "ardupilotmega" = ["common", "icarous", "uavionix"]
@@ -75,8 +75,8 @@ heapless = "0.7"
 "tcp" = []
 "direct-serial" = []
 "embedded" = ["embedded-hal", "nb"]
-"serde" = ["dep:serde", "heapless/serde"]
-default= ["std", "tcp", "udp", "direct-serial", "serial", "serde", "ardupilotmega"]
+"serde" = ["dep:serde", "dep:serde_arrays"]
+default = ["std", "tcp", "udp", "direct-serial", "serial", "serde", "ardupilotmega"]
 
 # build with all features on docs.rs so that users viewing documentation
 # can see everything

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -778,7 +778,7 @@ impl MavField {
         if matches!(self.mavtype, MavType::Array(_, _)) {
             let default_value = self.mavtype.emit_default_value();
             quote!(#field: #default_value,)
-        } else if let Some(ref enumname) = self.enumtype {
+        } else if let Some(enumname) = &self.enumtype {
             let ty = TokenStream::from_str(enumname).unwrap();
             quote!(#field: #ty::DEFAULT,)
         } else {

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -514,7 +514,11 @@ impl MavMessage {
                 // If sent by an implementation that doesn't have the extensions fields
                 // then the recipient will see zero values for the extensions fields.
                 let serde_default = if field.is_extension {
-                    quote!(#[cfg_attr(feature = "serde", serde(default))])
+                    if field.enumtype.is_some() {
+                        quote!(#[cfg_attr(feature = "serde", serde(default))])
+                    } else {
+                        quote!(#[cfg_attr(feature = "serde", serde(default = "crate::RustDefault::rust_default"))])
+                    }
                 } else {
                     quote!()
                 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use self::connection::{connect, MavConnection};
 
 mod utils;
 #[allow(unused_imports)]
-use utils::remove_trailing_zeroes;
+use utils::{remove_trailing_zeroes, RustDefault};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,6 +21,7 @@ pub(crate) fn remove_trailing_zeroes(data: &mut [u8]) -> usize {
 /// A trait very similar to `Default` but is only implemented for the equivalent Rust types to
 /// `MavType`s. This is only needed because rust doesn't currently implement `Default` for arrays
 /// of all sizes. In particular this trait is only ever used when the "serde" feature is enabled.
+/// For more information, check out [this issue](https://users.rust-lang.org/t/issue-for-derives-for-arrays-greater-than-size-32/59055/3).
 pub(crate) trait RustDefault: Copy {
     fn rust_default() -> Self;
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -17,3 +17,95 @@ pub(crate) fn remove_trailing_zeroes(data: &mut [u8]) -> usize {
 
     len
 }
+
+/// A trait very similar to `Default` but is only implemented for the equivalent Rust types to
+/// `MavType`s. This is only needed because rust doesn't currently implement `Default` for arrays
+/// of all sizes. In particular this trait is only ever used when the "serde" feature is enabled.
+pub(crate) trait RustDefault: Copy {
+    fn rust_default() -> Self;
+}
+
+impl<T: RustDefault, const N: usize> RustDefault for [T; N] {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        let val: T = RustDefault::rust_default();
+        [val; N]
+    }
+}
+
+impl RustDefault for u8 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for i8 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for u16 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for i16 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for u32 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for i32 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for u64 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for i64 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0
+    }
+}
+
+impl RustDefault for char {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        '\0'
+    }
+}
+
+impl RustDefault for f32 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0.0
+    }
+}
+
+impl RustDefault for f64 {
+    #[inline(always)]
+    fn rust_default() -> Self {
+        0.0
+    }
+}


### PR DESCRIPTION
This PR aims to remove the [`heapless`](https://crates.io/crates/heapless) dependency. Currently the implementation relies on `heapless::Vec` but doesn't have to. Removing this dependency reduces the ammount of code generated and the compile time. It also uses a `const DEFAULT` for default values of `*_DATA` types which can be used in `const fn`s.

Look at #156 for more context.