### PR TITLE
perf: improve code generation performance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ heapless = "0.7"
     "common",
 ]
 
+"format-generated-code" = []
 "emit-description" = []
 "emit-extensions" = []
 "std" = ["byteorder/std"]
@@ -81,4 +82,4 @@ default= ["std", "tcp", "udp", "direct-serial", "serial", "serde", "ardupilotmeg
 # build with all features on docs.rs so that users viewing documentation
 # can see everything
 [package.metadata.docs.rs]
-features = ["default", "all-dialects", "emit-description", "emit-extensions"]
+features = ["default", "all-dialects", "emit-description", "emit-extensions", "format-generated-code"]


### PR DESCRIPTION
Use `BufWriter` and avoid formatting generated code for faster build times.

**BEFORE**
![rust_mavlink_master_comptime](https://user-images.githubusercontent.com/13651052/226373854-aa6fbf8c-d155-48eb-8ea8-8a6ca42d9bc8.png)

**AFTER**
![rust_mavlink_better_comptime](https://user-images.githubusercontent.com/13651052/226373974-eaffdeee-8b44-4c6a-846b-d7a1f13f1964.png)

This PR still doesn't address the main issue which is the compilation time of the `mavlink` crate itself. But for a 14 line change I don't see a reason not to do this. It makes code generation 3x faster.

PS: The measurements were taken with `cargo clean` followed by `cargo b --test encode_decode_tests --timings` on a Ryzen 5 5600X processor.