### PR TITLE
parser: Remove dbg from quote call

### DIFF
--- a/build/parser.rs
+++ b/build/parser.rs
@@ -450,7 +450,7 @@ impl MavEnum {
             };
         }
 
-        dbg!(quote! {
+        quote! {
             #enum_def
 
             impl Default for #enum_name {
@@ -458,7 +458,7 @@ impl MavEnum {
                     Self::#default
                 }
             }
-        })
+        }
     }
 }
 


### PR DESCRIPTION
This call was increasing the build log from 20kB to 10MB, that's probably why rust docs are failing to build on their CI

Should help #169 