### PR TITLE
ci: Add documentation deployment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,3 +131,21 @@ jobs:
           override: true
       - name: Build
         run: cargo +nightly build --target thumbv7em-none-eabihf --manifest-path examples/embedded/Cargo.toml --out-dir $PWD --release -Z unstable-options
+
+  docs:
+    needs: internal-tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: actions-rs/toolchain@v1.0.6
+      with:
+        toolchain: stable
+        override: true
+    - name: Build docs
+      run: cargo doc
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: ${{ github.ref == 'refs/heads/master' }}
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./target/doc


### PR DESCRIPTION
Since docs.rs is failing to build, there is not enough ram, we should have our own docs in github pages. 