### PR TITLE
refactor 'internal tests' CI job to use github matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,21 +29,14 @@ jobs:
 
   internal-tests:
     runs-on: ubuntu-latest
+    strategy:
+        matrix:
+          dialect: ["ardupilotmega", "asluav", "autoquad", "matrixpilot", "minimal", "paparazzi", "python_array_test", "slugs", "standard", "test", "ualberta", "uavionix", "icarous", "common"]
     steps:
       - uses: actions/checkout@master
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: stable
+      - uses: dtolnay/rust-toolchain@stable
       - name: Run internal tests
-        run: |
-          dialects=("ardupilotmega", "asluav", "autoquad", "matrixpilot", "minimal", "paparazzi", "python_array_test", "slugs", "standard", "test", "ualberta", "uavionix", "icarous", "common")
-          for dialect in "${dialects[@]}"; do
-            echo "::group::Testing $dialect"
-            if ! cargo test --verbose --features "$dialect" -- --nocapture; then
-              echo "::error::Tests failed"
-            fi
-            echo "::endgroup::"
-          done
+        run: cargo test --verbose --features ${{ matrix.dialect }} -- --nocapture
 
   mavlink-dump:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          dialect: ["ardupilotmega", "asluav", "autoquad", "matrixpilot", "minimal", "paparazzi", "python_array_test", "slugs", "standard", "test", "ualberta", "uavionix", "icarous", "common"]
+          dialect: ["ardupilotmega", "asluav", "matrixpilot", "minimal", "paparazzi", "python_array_test", "slugs", "standard", "test", "ualberta", "uavionix", "icarous", "common"]
     steps:
       - uses: actions/checkout@master
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
use a github action 'matrix' rather than hand-rolling with a shell script

also removed the 'autoquad' feature, which doesn't seem to exist (the old script hid the error)