### PR TITLE
Fix sequence order in serialization function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,9 +154,9 @@ impl<M: Message> MavFrame<M> {
         let mut buf = bytes_mut::BytesMut::new(buf);
 
         // serialize header
+        buf.put_u8(self.header.sequence);
         buf.put_u8(self.header.system_id);
         buf.put_u8(self.header.component_id);
-        buf.put_u8(self.header.sequence);
 
         // message id
         match self.protocol_version {
@@ -180,9 +180,9 @@ impl<M: Message> MavFrame<M> {
     pub fn deser(version: MavlinkVersion, input: &[u8]) -> Result<Self, ParserError> {
         let mut buf = Bytes::new(input);
 
+        let sequence = buf.get_u8();
         let system_id = buf.get_u8();
         let component_id = buf.get_u8();
-        let sequence = buf.get_u8();
         let header = MavHeader {
             system_id,
             component_id,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,9 +180,9 @@ impl<M: Message> MavFrame<M> {
     pub fn deser(version: MavlinkVersion, input: &[u8]) -> Result<Self, ParserError> {
         let mut buf = Bytes::new(input);
 
-        let sequence = buf.get_u8();
         let system_id = buf.get_u8();
         let component_id = buf.get_u8();
+        let sequence = buf.get_u8();
         let header = MavHeader {
             system_id,
             component_id,


### PR DESCRIPTION
I am currently doing my bachelor's degree about MAVLink and LoRa. I decided to use rust and therefore rust-mavlink.
I need to serialize and deserialize MavFrames to send them over the LoRa link. While doing that, I noticed a weird behavior of the deser function. The order of serializing the header fields (system_id, component_id and sequence) does not align with the order of deserialization. 

Here is a screenshot showing the problem
![image](https://github.com/mavlink/rust-mavlink/assets/48621967/7d6952ab-6d54-423b-a41e-384aab6396f0)

Order of serialization
![image](https://github.com/mavlink/rust-mavlink/assets/48621967/0d2ce99e-1ccb-4e1f-b0bf-5745aead3d59)

Old order of deserialization
![image](https://github.com/mavlink/rust-mavlink/assets/48621967/3ea06dac-d578-479e-a93c-9bf017dfd9fc)

Also, if you look closely, the values are all over the place and do not match (it's not a corrupt message problem). I am going to open a separate issue for that (https://github.com/mavlink/rust-mavlink/issues/205), as I am still investigating it and is not related to the header.