### PR TITLE
Make embedded module public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ pub mod bytes_mut;
 pub mod error;
 
 #[cfg(feature = "embedded")]
-mod embedded;
+pub mod embedded;
 #[cfg(feature = "embedded")]
 use embedded::{Read, Write};
 


### PR DESCRIPTION
Embedded module redefines the Write and Read traits.

Right now it's a private module, when the library is compiled in embedded mode, the following problem occurs :

![imagen](https://github.com/mavlink/rust-mavlink/assets/74329840/40c46bd4-e31e-4169-8f09-a80f5beb90dc)

Write is non-accesible, both while checking the documentation, but more important, when you integrate this library into your code, you can't define a function that receives an argument that needs to implement the custom Read or Write trait.

Example:

```
pub fn send_command<W: Write>(
    &mut self,
    cmd: FooCommandMsgType,
    writer: &mut W,
) -> Result<u16, FooError> {

...

write_v2_msg(
                writer,
                foo_header,
                &foo_message,
            ),

...
```

The following cases only work when compiled in normal (non-embedded) modes.