### PR TITLE
Bugfix. Replace default isize enum representation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ with bindings for all message sets.
 Add to your Cargo.toml:
 
 ```
-mavlink = "0.10.1"
+mavlink = "0.12.2"
 ```
 
 ## Examples

--- a/build/parser.rs
+++ b/build/parser.rs
@@ -180,6 +180,7 @@ impl MavProfile {
         quote! {
             #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
             #[cfg_attr(feature = "serde", serde(tag = "type"))]
+            #[repr(u32)]
             pub enum MavMessage {
                 #(#enums(#structs),)*
             }
@@ -390,6 +391,7 @@ impl MavEnum {
                 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
                 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
                 #[cfg_attr(feature = "serde", serde(tag = "type"))]
+                #[repr(u32)]
                 #description
                 pub enum #enum_name {
                     #(#defs)*


### PR DESCRIPTION
By default Rust uses isize to represent enum values. isize implementation depends on the `target_pointer_width` attribute, which differs from arch to arch.

- Mavlink implementation for v2 requires message id with the range 0..16777215 --> u32
- Mavlink implementation requires u32 enum entry values

Closes #211 