### PR TITLE
Move mavlink-dump from src/bin to examples/mavlink-dump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: dtolnay/rust-toolchain@stable
       - name: Build mavlink-dump
-        run: cargo build --verbose --bin mavlink-dump --features ardupilotmega
+        run: cargo build --verbose --example mavlink-dump
 
   msrv:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,9 @@ proc-macro2 = "1.0.43"
 lazy_static = "1.2.0"
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 
-[[bin]]
+[[example]]
 name = "mavlink-dump"
+path = "examples/mavlink-dump/src/main.rs"
 required-features = ["ardupilotmega"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,29 @@ mavlink = "0.12.2"
 ```
 
 ## Examples
-See [src/bin/mavlink-dump.rs](src/bin/mavlink-dump.rs) for a usage example.
+See [examples/](examples/mavlink-dump/src/main) for different usage examples.
+
+### mavlink-dump
+[examples/mavlink-dump](examples/mavlink-dump/src/main) contains an executable example that can be used to test message reception.
+
+It can be executed directly by running:
+```
+cargo run --example mavlink-dump [options]
+```
 
 It's also possible to install the working example via `cargo` command line:
 ```sh
-cargo install mavlink
+cargo install --path examples/mavlink-dump
+```
+
+It can then be executed by running:
+```
+mavlink-dump [options]
+```
+
+Execution call example:
+```sh
+mavlink-dump udpin:127.0.0.1:14540
 ```
 
 ### Community projects

--- a/examples/mavlink-dump/Cargo.toml
+++ b/examples/mavlink-dump/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "mavlink-dump"
+authors = [
+    "Patrick José Pereira <patrickelectric@gmail.com>",
+]
+license = "MIT/Apache-2.0"
+edition = "2018"
+version = "0.1.0"
+
+[profile.release]
+opt-level = 3
+lto = true # Performs "fat" LTO which attempts to perform optimizations across all crates within the dependency graph
+
+[dependencies.mavlink] # MAVLink library
+path = "../../"

--- a/examples/mavlink-dump/src/main.rs
+++ b/examples/mavlink-dump/src/main.rs
@@ -1,11 +1,6 @@
 use mavlink::error::MessageReadError;
-#[cfg(feature = "std")]
 use std::{env, sync::Arc, thread, time::Duration};
 
-#[cfg(not(feature = "std"))]
-fn main() {}
-
-#[cfg(feature = "std")]
 fn main() {
     let args: Vec<_> = env::args().collect();
 
@@ -65,7 +60,6 @@ fn main() {
 }
 
 /// Create a heartbeat message using 'ardupilotmega' dialect
-#[cfg(feature = "std")]
 pub fn heartbeat_message() -> mavlink::ardupilotmega::MavMessage {
     mavlink::ardupilotmega::MavMessage::HEARTBEAT(mavlink::ardupilotmega::HEARTBEAT_DATA {
         custom_mode: 0,
@@ -78,7 +72,6 @@ pub fn heartbeat_message() -> mavlink::ardupilotmega::MavMessage {
 }
 
 /// Create a message requesting the parameters list
-#[cfg(feature = "std")]
 pub fn request_parameters() -> mavlink::ardupilotmega::MavMessage {
     mavlink::ardupilotmega::MavMessage::PARAM_REQUEST_LIST(
         mavlink::ardupilotmega::PARAM_REQUEST_LIST_DATA {
@@ -89,7 +82,6 @@ pub fn request_parameters() -> mavlink::ardupilotmega::MavMessage {
 }
 
 /// Create a message enabling data streaming
-#[cfg(feature = "std")]
 pub fn request_stream() -> mavlink::ardupilotmega::MavMessage {
     mavlink::ardupilotmega::MavMessage::REQUEST_DATA_STREAM(
         mavlink::ardupilotmega::REQUEST_DATA_STREAM_DATA {


### PR DESCRIPTION
Refactor mavlink-dump. Change from [[bin]] to [[example]].

Splitting the example has the following benefits:
- Faster compilation for library use, as the example doesn't get compiled by default
- Easier to retain compilation incremental files (faster re-compilation times)
- Cleaner library src/ directory
- std checks and imports can be removed from the mavlink-dump example -> cleaner example. no_std version didn't do anything
- Executable name changes from mavlink -> mavlink-dump. More precise to locate and guess what it is for

Disadvantage:
- Installation time for the example is increased (at least on my short tests), but it is something rarely done.

When running `cargo run --example mavlink-dump` compilation time and execution stays the same or better (easier to retain compilation incremental files)


#### Installation output
```
/rust-mavlink$ cargo install --path examples/mavlink-dump
  Installing mavlink-dump v0.1.0 (/foo/rust-mavlink/examples/mavlink-dump)
    Updating crates.io index
    Finished release [optimized] target(s) in 1.91s
   Replacing /foo/.cargo/bin/mavlink-dump
    Replaced package `mavlink-dump v0.1.0 (/foo/rust-mavlink/examples/mavlink-dump)` with `mavlink-dump v0.1.0 (/foo/examples/mavlink-dump)` (executable `mavlink-dump`)
```

#### Empty args execution
```
rust-mavlink$ mavlink-dump
Usage: mavlink-dump (tcpout|tcpin|udpout|udpin|udpbcast|serial|file):(ip|dev|path):(port|baud)
```