### PR TITLE
Fix message framing (backtracking parser)

### DIFF
--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -24,7 +24,6 @@ nb = { version = "1.0", optional = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
 serial = { version = "0.4", optional = true }
-buffered-reader = { version = "1.3.0", default-features = false }
 
 [features]
 "std" = ["byteorder/std"]

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -1,7 +1,14 @@
 [package]
 name = "mavlink-core"
 version = "0.12.2"
-authors = ["Todd Stellanova", "Michal Podhradsky", "Kevin Mehall", "Tim Ryan", "Patrick José Pereira", "Ibiyemi Abiodun"]
+authors = [
+    "Todd Stellanova",
+    "Michal Podhradsky",
+    "Kevin Mehall",
+    "Tim Ryan",
+    "Patrick José Pereira",
+    "Ibiyemi Abiodun",
+]
 description = "Implements the MAVLink data interchange format for UAVs."
 readme = "README.md"
 license = "MIT/Apache-2.0"
@@ -17,6 +24,7 @@ nb = { version = "1.0", optional = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
 serial = { version = "0.4", optional = true }
+buffered-reader = { version = "1.3.0", default-features = false }
 
 [features]
 "std" = ["byteorder/std"]

--- a/mavlink-core/src/connection/direct_serial.rs
+++ b/mavlink-core/src/connection/direct_serial.rs
@@ -1,12 +1,43 @@
 use crate::connection::MavConnection;
 use crate::{read_versioned_msg, write_versioned_msg, MavHeader, MavlinkVersion, Message};
-use std::io;
+use core::ops::DerefMut;
+use std::io::{self, Read, Write};
 use std::sync::Mutex;
 
 use crate::error::{MessageReadError, MessageWriteError};
-use serial::prelude::*;
+use serial::{prelude::*, SystemPort};
 
 /// Serial MAVLINK connection
+
+struct SyncSystemPort(Mutex<SystemPort>);
+
+impl Read for SyncSystemPort {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut port = match self.0.lock() {
+            Ok(port) => port,
+            Err(err) => err.into_inner(),
+        };
+        port.read(buf)
+    }
+}
+
+impl Write for SyncSystemPort {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut port = match self.0.lock() {
+            Ok(port) => port,
+            Err(err) => err.into_inner(),
+        };
+        port.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        let mut port = match self.0.lock() {
+            Ok(port) => port,
+            Err(err) => err.into_inner(),
+        };
+        port.flush()
+    }
+}
 
 pub fn open(settings: &str) -> io::Result<SerialConnection> {
     let settings_toks: Vec<&str> = settings.split(':').collect();
@@ -40,14 +71,17 @@ pub fn open(settings: &str) -> io::Result<SerialConnection> {
     port.configure(&settings)?;
 
     Ok(SerialConnection {
-        port: Mutex::new(port),
+        port: Mutex::new(buffered_reader::Generic::new(
+            SyncSystemPort(Mutex::new(port)),
+            None,
+        )),
         sequence: Mutex::new(0),
         protocol_version: MavlinkVersion::V2,
     })
 }
 
 pub struct SerialConnection {
-    port: Mutex<serial::SystemPort>,
+    port: Mutex<buffered_reader::Generic<SyncSystemPort, ()>>,
     sequence: Mutex<u8>,
     protocol_version: MavlinkVersion,
 }
@@ -55,9 +89,8 @@ pub struct SerialConnection {
 impl<M: Message> MavConnection<M> for SerialConnection {
     fn recv(&self) -> Result<(MavHeader, M), MessageReadError> {
         let mut port = self.port.lock().unwrap();
-
         loop {
-            match read_versioned_msg(&mut *port, self.protocol_version) {
+            match read_versioned_msg(port.deref_mut(), self.protocol_version) {
                 ok @ Ok(..) => {
                     return ok;
                 }
@@ -83,7 +116,7 @@ impl<M: Message> MavConnection<M> for SerialConnection {
 
         *sequence = sequence.wrapping_add(1);
 
-        write_versioned_msg(&mut *port, self.protocol_version, header, data)
+        write_versioned_msg(port.reader_mut(), self.protocol_version, header, data)
     }
 
     fn set_protocol_version(&mut self, version: MavlinkVersion) {

--- a/mavlink-core/src/connection/file.rs
+++ b/mavlink-core/src/connection/file.rs
@@ -1,5 +1,6 @@
 use crate::connection::MavConnection;
 use crate::error::{MessageReadError, MessageWriteError};
+use crate::peek_reader::PeekReader;
 use crate::{read_versioned_msg, MavHeader, MavlinkVersion, Message};
 use core::ops::DerefMut;
 use std::fs::File;
@@ -12,13 +13,13 @@ pub fn open(file_path: &str) -> io::Result<FileConnection> {
     let file = File::open(file_path)?;
 
     Ok(FileConnection {
-        file: Mutex::new(buffered_reader::Generic::new(file, None)),
+        file: Mutex::new(PeekReader::new(file)),
         protocol_version: MavlinkVersion::V2,
     })
 }
 
 pub struct FileConnection {
-    file: Mutex<buffered_reader::Generic<File, ()>>,
+    file: Mutex<PeekReader<File>>,
     protocol_version: MavlinkVersion,
 }
 

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -1,7 +1,29 @@
+//! This module implements a buffered/peekable reader.
+//!
+//! The purpose of the buffered/peekable reader is to allow for backtracking parsers.
+//!
+//! A reader implementing the standard librairy's [`std::io::BufRead`] trait seems like a good fit, but
+//! it does not allow for peeking a specific number of bytes, so it provides no way to request
+//! more data from the underlying reader without consuming the existing data.
+//!
+//! This API still tries to adhere to the [`std::io::BufRead`]'s trait philosophy.
+//!
+//! The main type `PeekReader`does not implement [`std::io::Read`] itself, as there is no added benefit
+//! in doing so.
+//!
+
 use std::io::{self, ErrorKind, Read};
 
+// The default chunk size to read from the underlying reader
 const DEFAULT_CHUNK_SIZE: usize = 1024;
 
+/// A buffered/peekable reader
+///
+/// This reader wraps a type implementing [`std::io::Read`] and adds buffering via an internal buffer.
+///
+/// It allows the user to `peek` a specified number of bytes (without consuming them),
+/// to `read` bytes (consuming them), or to `consume` them after `peek`ing.
+///
 pub struct PeekReader<R> {
     // Internal buffer
     buffer: Vec<u8>,
@@ -13,15 +35,17 @@ pub struct PeekReader<R> {
     reader: R,
     // Stashed error, if any.
     error: Option<io::Error>,
-    /// Whether we hit EOF on the underlying reader.
+    // Whether we hit EOF on the underlying reader.
     eof: bool,
 }
 
 impl<R: Read> PeekReader<R> {
+    /// Instanciates a new [`PeekReader`], wrapping the provided [`std::io::Read`]er and using the default chunk size
     pub fn new(reader: R) -> Self {
         Self::with_chunk_size(reader, DEFAULT_CHUNK_SIZE)
     }
 
+    /// Instanciates a new [`PeekReader`], wrapping the provided [`std::io::Read`]er and using the supplied chunk size
     pub fn with_chunk_size(reader: R, preferred_chunk_size: usize) -> Self {
         Self {
             buffer: Vec::with_capacity(preferred_chunk_size),
@@ -33,41 +57,95 @@ impl<R: Read> PeekReader<R> {
         }
     }
 
+    /// Peeks a specified amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// This function does not consume  data from the buffer, so subsequent calls to `peek` or `read` functions
+    /// will still return the peeked data.
+    ///
     pub fn peek(&mut self, amount: usize) -> io::Result<&[u8]> {
         self.fetch(amount, false, false)
     }
 
+    /// Peeks an exact amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function does not consume data from the buffer, so subsequent calls to `peek` or `read` functions
+    /// will still return the peeked data.
+    ///
     pub fn peek_exact(&mut self, amount: usize) -> io::Result<&[u8]> {
         self.fetch(amount, true, false)
     }
 
+    /// Consumes a specified amount of bytes from the buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will consume as much data as is buffered.
+    ///
     pub fn consume(&mut self, amount: usize) -> usize {
         let amount = amount.min(self.buffer.len() - self.cursor);
         self.cursor += amount;
         amount
     }
 
+    /// Reads a specified amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
+    ///
     pub fn read(&mut self, amount: usize) -> io::Result<&[u8]> {
         self.fetch(amount, false, true)
     }
 
+    /// Reads a specified amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
+    ///
     pub fn read_exact(&mut self, amount: usize) -> io::Result<&[u8]> {
         self.fetch(amount, true, true)
     }
 
+    /// Reads a byte from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
+    ///
     pub fn read_u8(&mut self) -> io::Result<u8> {
         let buf = self.read_exact(1)?;
         Ok(buf[0])
     }
 
+    /// Returns an immutable reference to the underlying [`std::io::Read`]er
+    ///
+    /// Reading directly from the underlying stream will cause data loss
     pub fn reader_ref(&mut self) -> &R {
         &self.reader
     }
 
+    /// Returns a mutable reference to the underlying [`std::io::Read`]er
+    ///
+    /// Reading directly from the underlying stream will cause data loss
     pub fn reader_mut(&mut self) -> &mut R {
         &mut self.reader
     }
 
+    /// Internal function to fetch data from the internal buffer and/or reader
     fn fetch(&mut self, amount: usize, exact: bool, consume: bool) -> io::Result<&[u8]> {
         let previous_len = self.buffer.len();
         let mut buffered = previous_len - self.cursor;
@@ -109,6 +187,7 @@ impl<R: Read> PeekReader<R> {
                     }
                 }
             }
+            // if some bytes were read, add them to the buffer
             if read > 0 {
                 if self.buffer.capacity() - previous_len < read {
                     // reallocate

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -1,0 +1,139 @@
+use std::io::{self, ErrorKind, Read};
+
+const DEFAULT_CHUNK_SIZE: usize = 1024;
+
+pub struct PeekReader<R> {
+    // Internal buffer
+    buffer: Vec<u8>,
+    // The position of the next byte to read in the buffer.
+    cursor: usize,
+    // The preferred chunk size.  This is just a hint.
+    preferred_chunk_size: usize,
+    // The wrapped reader.
+    reader: R,
+    // Stashed error, if any.
+    error: Option<io::Error>,
+    /// Whether we hit EOF on the underlying reader.
+    eof: bool,
+}
+
+impl<R: Read> PeekReader<R> {
+    pub fn new(reader: R) -> Self {
+        Self::with_chunk_size(reader, DEFAULT_CHUNK_SIZE)
+    }
+
+    pub fn with_chunk_size(reader: R, preferred_chunk_size: usize) -> Self {
+        Self {
+            buffer: Vec::with_capacity(preferred_chunk_size),
+            cursor: 0,
+            preferred_chunk_size,
+            reader,
+            error: None,
+            eof: false,
+        }
+    }
+
+    pub fn peek(&mut self, amount: usize) -> io::Result<&[u8]> {
+        self.fetch(amount, false, false)
+    }
+
+    pub fn peek_exact(&mut self, amount: usize) -> io::Result<&[u8]> {
+        self.fetch(amount, true, false)
+    }
+
+    pub fn consume(&mut self, amount: usize) -> usize {
+        let amount = amount.min(self.buffer.len() - self.cursor);
+        self.cursor += amount;
+        amount
+    }
+
+    pub fn read(&mut self, amount: usize) -> io::Result<&[u8]> {
+        self.fetch(amount, false, true)
+    }
+
+    pub fn read_exact(&mut self, amount: usize) -> io::Result<&[u8]> {
+        self.fetch(amount, true, true)
+    }
+
+    pub fn read_u8(&mut self) -> io::Result<u8> {
+        let buf = self.read_exact(1)?;
+        Ok(buf[0])
+    }
+
+    pub fn reader_ref(&mut self) -> &R {
+        &self.reader
+    }
+
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    fn fetch(&mut self, amount: usize, exact: bool, consume: bool) -> io::Result<&[u8]> {
+        let previous_len = self.buffer.len();
+        let mut buffered = previous_len - self.cursor;
+
+        // the caller requested more bytes tha we have buffered, fetch them from the reader
+        if buffered < amount {
+            // if we got an earlier EOF, return it
+            if self.eof {
+                return Err(io::Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "Unexpected EOF already returned in previous call to reader",
+                ));
+            }
+            // if we have a stashed error, return it (and clear it)
+            if let Some(e) = self.error.take() {
+                if e.kind() == ErrorKind::UnexpectedEof {
+                    self.eof = true;
+                }
+                return Err(e);
+            }
+
+            let needed = amount - buffered;
+            let chunk_size = self.preferred_chunk_size.max(needed);
+            let mut buf = vec![0u8; chunk_size];
+
+            // read needed bytes from reader
+            let mut read = 0;
+            while read < needed {
+                match self.reader.read(&mut buf[read..]) {
+                    Ok(n) => {
+                        if n == 0 {
+                            break;
+                        }
+                        read += n;
+                    }
+                    Err(e) => {
+                        self.error = Some(e);
+                        break;
+                    }
+                }
+            }
+            if read > 0 {
+                if self.buffer.capacity() - previous_len < read {
+                    // reallocate
+                    self.buffer
+                        .copy_within(self.cursor..self.cursor + buffered, 0);
+                    self.buffer.truncate(buffered);
+                    self.cursor = 0;
+                }
+                self.buffer.extend_from_slice(&buf[..read]);
+                buffered += read;
+            }
+
+            if buffered == 0 && self.error.is_some() {
+                return Err(self.error.take().unwrap());
+            }
+        }
+        if exact && buffered < amount {
+            return Err(io::Error::new(ErrorKind::UnexpectedEof, "Unexpected EOF"));
+        }
+
+        let result_len = amount.min(buffered);
+        let result = &self.buffer[self.cursor..self.cursor + result_len];
+        if consume {
+            self.cursor += result_len;
+        }
+        Ok(result)
+    }
+}

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -33,7 +33,6 @@ num-derive = { workspace = true }
 bitflags = { workspace = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
-buffered-reader = { version = "1.3.0", default-features = false }
 
 [features]
 "all" = [

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -2,7 +2,14 @@
 [package]
 name = "mavlink"
 version = "0.12.2"
-authors = ["Todd Stellanova", "Michal Podhradsky", "Kevin Mehall", "Tim Ryan", "Patrick José Pereira", "Ibiyemi Abiodun"]
+authors = [
+    "Todd Stellanova",
+    "Michal Podhradsky",
+    "Kevin Mehall",
+    "Tim Ryan",
+    "Patrick José Pereira",
+    "Ibiyemi Abiodun",
+]
 build = "build/main.rs"
 description = "Implements the MAVLink data interchange format for UAVs."
 readme = "README.md"
@@ -12,7 +19,7 @@ edition = "2018"
 rust-version = "1.65.0"
 
 [build-dependencies]
-mavlink-bindgen = { path = "../mavlink-bindgen", default-features = false}
+mavlink-bindgen = { path = "../mavlink-bindgen", default-features = false }
 
 [[example]]
 name = "mavlink-dump"
@@ -20,12 +27,13 @@ path = "examples/mavlink-dump/src/main.rs"
 required-features = ["ardupilotmega"]
 
 [dependencies]
-mavlink-core = { path = "../mavlink-core", default-features = false}
+mavlink-core = { path = "../mavlink-core", default-features = false }
 num-traits = { workspace = true, default-features = false }
 num-derive = { workspace = true }
 bitflags = { workspace = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
+buffered-reader = { version = "1.3.0", default-features = false }
 
 [features]
 "all" = [
@@ -93,4 +101,10 @@ default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega"]
 # build with all features on docs.rs so that users viewing documentation
 # can see everything
 [package.metadata.docs.rs]
-features = ["default", "all-dialects", "emit-description", "emit-extensions", "format-generated-code"]
+features = [
+    "default",
+    "all-dialects",
+    "emit-description",
+    "emit-extensions",
+    "format-generated-code",
+]

--- a/mavlink/tests/encode_decode_tests.rs
+++ b/mavlink/tests/encode_decode_tests.rs
@@ -3,6 +3,7 @@ mod test_shared;
 #[cfg(feature = "common")]
 mod test_encode_decode {
     use mavlink::{common, Message};
+    use mavlink_core::peek_reader::PeekReader;
 
     #[test]
     pub fn test_echo_heartbeat() {
@@ -16,7 +17,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg): (mavlink::MavHeader, common::MavMessage) =
             mavlink::read_v2_msg(&mut c).expect("Failed to read");
         assert_eq!(recv_msg.message_id(), 0);
@@ -34,7 +35,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         if let common::MavMessage::COMMAND_INT(recv_msg) = recv_msg {
@@ -56,7 +57,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
         if let mavlink::common::MavMessage::HIL_ACTUATOR_CONTROLS(recv_msg) = recv_msg {
             assert_eq!(
@@ -85,7 +86,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         match &recv_msg {
@@ -114,7 +115,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
         if let ardupilotmega::MavMessage::MOUNT_STATUS(recv_msg) = recv_msg {
             assert_eq!(4, recv_msg.pointing_b);
@@ -138,7 +139,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         match &recv_msg {

--- a/mavlink/tests/encode_decode_tests.rs
+++ b/mavlink/tests/encode_decode_tests.rs
@@ -16,7 +16,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = buffered_reader::Memory::new(v.as_slice());
         let (_header, recv_msg): (mavlink::MavHeader, common::MavMessage) =
             mavlink::read_v2_msg(&mut c).expect("Failed to read");
         assert_eq!(recv_msg.message_id(), 0);
@@ -34,7 +34,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = buffered_reader::Memory::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         if let common::MavMessage::COMMAND_INT(recv_msg) = recv_msg {
@@ -56,7 +56,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = buffered_reader::Memory::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
         if let mavlink::common::MavMessage::HIL_ACTUATOR_CONTROLS(recv_msg) = recv_msg {
             assert_eq!(
@@ -85,9 +85,8 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
-        let (_header, recv_msg) = mavlink::read_v2_msg::<ardupilotmega::MavMessage, &[u8]>(&mut c)
-            .expect("Failed to read");
+        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         match &recv_msg {
             ardupilotmega::MavMessage::HEARTBEAT(_data) => {
@@ -115,7 +114,7 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = buffered_reader::Memory::new(v.as_slice());
         let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
         if let ardupilotmega::MavMessage::MOUNT_STATUS(recv_msg) = recv_msg {
             assert_eq!(4, recv_msg.pointing_b);
@@ -139,9 +138,8 @@ mod test_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
-        let (_header, recv_msg) = mavlink::read_v2_msg::<ardupilotmega::MavMessage, &[u8]>(&mut c)
-            .expect("Failed to read");
+        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let (_header, recv_msg) = mavlink::read_v2_msg(&mut c).expect("Failed to read");
 
         match &recv_msg {
             ardupilotmega::MavMessage::COMMAND_INT(data) => {

--- a/mavlink/tests/process_log_files.rs
+++ b/mavlink/tests/process_log_files.rs
@@ -49,7 +49,7 @@ mod process_files {
 
         println!("Number of parsed messages: {counter}");
         assert!(
-            counter == 1374,
+            counter == 1426,
             "Unable to hit the necessary amount of matches"
         );
     }

--- a/mavlink/tests/v1_encode_decode_tests.rs
+++ b/mavlink/tests/v1_encode_decode_tests.rs
@@ -2,6 +2,7 @@ pub mod test_shared;
 
 #[cfg(all(feature = "std", feature = "common"))]
 mod test_v1_encode_decode {
+    use mavlink_core::peek_reader::PeekReader;
 
     pub const HEARTBEAT_V1: &[u8] = &[
         mavlink::MAV_STX,
@@ -25,7 +26,7 @@ mod test_v1_encode_decode {
 
     #[test]
     pub fn test_read_heartbeat() {
-        let mut r = buffered_reader::Memory::new(HEARTBEAT_V1);
+        let mut r = PeekReader::new(HEARTBEAT_V1);
         let (header, msg) = mavlink::read_v1_msg(&mut r).expect("Failed to parse message");
         //println!("{:?}, {:?}", header, msg);
 
@@ -73,7 +74,7 @@ mod test_v1_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = buffered_reader::Memory::new(v.as_slice());
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg): (mavlink::MavHeader, mavlink::common::MavMessage) =
             mavlink::read_v2_msg(&mut c).expect("Failed to read");
 

--- a/mavlink/tests/v1_encode_decode_tests.rs
+++ b/mavlink/tests/v1_encode_decode_tests.rs
@@ -25,7 +25,7 @@ mod test_v1_encode_decode {
 
     #[test]
     pub fn test_read_heartbeat() {
-        let mut r = HEARTBEAT_V1;
+        let mut r = buffered_reader::Memory::new(HEARTBEAT_V1);
         let (header, msg) = mavlink::read_v1_msg(&mut r).expect("Failed to parse message");
         //println!("{:?}, {:?}", header, msg);
 
@@ -73,7 +73,7 @@ mod test_v1_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = buffered_reader::Memory::new(v.as_slice());
         let (_header, recv_msg): (mavlink::MavHeader, mavlink::common::MavMessage) =
             mavlink::read_v2_msg(&mut c).expect("Failed to read");
 

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -2,6 +2,8 @@ mod test_shared;
 
 #[cfg(all(feature = "std", feature = "common"))]
 mod test_v2_encode_decode {
+    use mavlink_core::peek_reader::PeekReader;
+
     pub const HEARTBEAT_V2: &[u8] = &[
         mavlink::MAV_STX_V2, //magic
         0x09,                //payload len
@@ -28,7 +30,7 @@ mod test_v2_encode_decode {
 
     #[test]
     pub fn test_read_v2_heartbeat() {
-        let mut r = buffered_reader::Memory::new(HEARTBEAT_V2);
+        let mut r = PeekReader::new(HEARTBEAT_V2);
         let (header, msg) = mavlink::read_v2_msg(&mut r).expect("Failed to parse message");
 
         assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
@@ -110,7 +112,7 @@ mod test_v2_encode_decode {
 
     #[test]
     pub fn test_read_truncated_command_long() {
-        let mut r = buffered_reader::Memory::new(COMMAND_LONG_TRUNCATED_V2);
+        let mut r = PeekReader::new(COMMAND_LONG_TRUNCATED_V2);
         let (_header, recv_msg) =
             mavlink::read_v2_msg(&mut r).expect("Failed to parse COMMAND_LONG_TRUNCATED_V2");
 
@@ -139,7 +141,7 @@ mod test_v2_encode_decode {
         )
         .expect("Failed to write message");
 
-        let mut c = v.as_slice();
+        let mut c = PeekReader::new(v.as_slice());
         let (_header, recv_msg): (mavlink::MavHeader, mavlink::common::MavMessage) =
             mavlink::read_v2_msg(&mut c).expect("Failed to read");
 

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -28,7 +28,7 @@ mod test_v2_encode_decode {
 
     #[test]
     pub fn test_read_v2_heartbeat() {
-        let mut r = HEARTBEAT_V2;
+        let mut r = buffered_reader::Memory::new(HEARTBEAT_V2);
         let (header, msg) = mavlink::read_v2_msg(&mut r).expect("Failed to parse message");
 
         assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
@@ -110,7 +110,7 @@ mod test_v2_encode_decode {
 
     #[test]
     pub fn test_read_truncated_command_long() {
-        let mut r = COMMAND_LONG_TRUNCATED_V2;
+        let mut r = buffered_reader::Memory::new(COMMAND_LONG_TRUNCATED_V2);
         let (_header, recv_msg) =
             mavlink::read_v2_msg(&mut r).expect("Failed to parse COMMAND_LONG_TRUNCATED_V2");
 


### PR DESCRIPTION
This PR fixes an issue where the parser can detect a STX byte that's not really a start of frame marker, but a random byte in the middle of a message, and then consume the next (few) real start-of-frame marker(s) as part of the incorrectly identified frame.

This situation can happen upon (re)connection or over lossy connections (e.g. radio) where some bytes are occasionally lost.
Although the parser will most likely resynchronise at some point (not guaranteed), this issue will still cause the loss of messages that have otherwise been correctly received in full.

The solution implemented is to use a buffered/peekable reader that can backtrack once the CRC is found to be incorrect.

In addition, this PR moves the CRC check to `read_vX_message_raw`, which ensures that a call to this function will always produce a valid Mavlink frame (raw message).

fixes #222 