### PR TITLE
changed `main` to `main.rs` for markdown hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ mavlink = "0.12.2"
 ```
 
 ## Examples
-See [examples/](mavlink/examples/mavlink-dump/src/main) for different usage examples.
+See [examples/](mavlink/examples/mavlink-dump/src/main.rs) for different usage examples.
 
 ### mavlink-dump
-[examples/mavlink-dump](mavlink/examples/mavlink-dump/src/main) contains an executable example that can be used to test message reception.
+[examples/mavlink-dump](mavlink/examples/mavlink-dump/src/main.rs) contains an executable example that can be used to test message reception.
 
 It can be executed directly by running:
 ```


### PR DESCRIPTION
Markdown links to examples were forgetting to add the filename extension. This leads to a 404 not found error when clicking on the hyperlink. By adding the file extension, the hyperlink can now correctly resolve.