### PR TITLE
Improve final binary size

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -505,10 +505,10 @@ impl MavMessage {
         quote! {
             let mut __tmp = BytesMut::new(bytes);
             assert!(
-                __tmp.len() >= Self::ENCODED_LEN,
+                __tmp.remaining() >= Self::ENCODED_LEN,
                 "buffer is too small (need {} bytes, but got {})",
                 Self::ENCODED_LEN,
-                __tmp.len(),
+                __tmp.remaining(),
             );
             #(#ser_vars)*
             if matches!(version, MavlinkVersion::V2) {

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -504,6 +504,12 @@ impl MavMessage {
         let ser_vars = self.fields.iter().map(|f| f.rust_writer());
         quote! {
             let mut __tmp = BytesMut::new(bytes);
+            assert!(
+                __tmp.len() >= Self::ENCODED_LEN,
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.len(),
+            );
             #(#ser_vars)*
             if matches!(version, MavlinkVersion::V2) {
                 let len = __tmp.len();

--- a/mavlink-core/src/bytes.rs
+++ b/mavlink-core/src/bytes.rs
@@ -13,10 +13,12 @@ impl<'a> Bytes<'a> {
         self.data.len() - self.pos
     }
 
+    #[inline]
     pub fn remaining_bytes(&self) -> &'a [u8] {
         &self.data[self.pos..]
     }
 
+    #[inline]
     fn check_remaining(&self, count: usize) {
         assert!(
             self.remaining() >= count,
@@ -26,6 +28,7 @@ impl<'a> Bytes<'a> {
         );
     }
 
+    #[inline]
     pub fn get_bytes(&mut self, count: usize) -> &[u8] {
         self.check_remaining(count);
 
@@ -34,6 +37,7 @@ impl<'a> Bytes<'a> {
         bytes
     }
 
+    #[inline]
     pub fn get_array<const SIZE: usize>(&mut self) -> [u8; SIZE] {
         let bytes = self.get_bytes(SIZE);
         let mut arr = [0u8; SIZE];
@@ -45,6 +49,7 @@ impl<'a> Bytes<'a> {
         arr
     }
 
+    #[inline]
     pub fn get_u8(&mut self) -> u8 {
         self.check_remaining(1);
 
@@ -53,6 +58,7 @@ impl<'a> Bytes<'a> {
         val
     }
 
+    #[inline]
     pub fn get_i8(&mut self) -> i8 {
         self.check_remaining(1);
 
@@ -61,14 +67,17 @@ impl<'a> Bytes<'a> {
         val
     }
 
+    #[inline]
     pub fn get_u16_le(&mut self) -> u16 {
         u16::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_i16_le(&mut self) -> i16 {
         i16::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_u24_le(&mut self) -> u32 {
         const SIZE: usize = 3;
         self.check_remaining(SIZE);
@@ -81,6 +90,7 @@ impl<'a> Bytes<'a> {
         u32::from_le_bytes(val)
     }
 
+    #[inline]
     pub fn get_i24_le(&mut self) -> i32 {
         const SIZE: usize = 3;
         self.check_remaining(SIZE);
@@ -93,26 +103,32 @@ impl<'a> Bytes<'a> {
         i32::from_le_bytes(val)
     }
 
+    #[inline]
     pub fn get_u32_le(&mut self) -> u32 {
         u32::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_i32_le(&mut self) -> i32 {
         i32::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_u64_le(&mut self) -> u64 {
         u64::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_i64_le(&mut self) -> i64 {
         i64::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_f32_le(&mut self) -> f32 {
         f32::from_le_bytes(self.get_array())
     }
 
+    #[inline]
     pub fn get_f64_le(&mut self) -> f64 {
         f64::from_le_bytes(self.get_array())
     }

--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -33,6 +33,7 @@ impl<'a> BytesMut<'a> {
         );
     }
 
+    #[inline]
     pub fn put_slice(&mut self, src: &[u8]) {
         self.check_remaining(src.len());
 
@@ -42,6 +43,7 @@ impl<'a> BytesMut<'a> {
         self.len += src.len();
     }
 
+    #[inline]
     pub fn put_u8(&mut self, val: u8) {
         self.check_remaining(1);
 
@@ -49,6 +51,7 @@ impl<'a> BytesMut<'a> {
         self.len += 1;
     }
 
+    #[inline]
     pub fn put_i8(&mut self, val: i8) {
         self.check_remaining(1);
 
@@ -56,6 +59,7 @@ impl<'a> BytesMut<'a> {
         self.len += 1;
     }
 
+    #[inline]
     pub fn put_u16_le(&mut self, val: u16) {
         const SIZE: usize = core::mem::size_of::<u16>();
         self.check_remaining(SIZE);
@@ -65,6 +69,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_i16_le(&mut self, val: i16) {
         const SIZE: usize = core::mem::size_of::<i16>();
         self.check_remaining(SIZE);
@@ -74,6 +79,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_u24_le(&mut self, val: u32) {
         const SIZE: usize = 3;
         const MAX: u32 = 2u32.pow(24) - 1;
@@ -91,6 +97,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_i24_le(&mut self, val: i32) {
         const SIZE: usize = 3;
         const MIN: i32 = 2i32.pow(23);
@@ -116,6 +123,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_u32_le(&mut self, val: u32) {
         const SIZE: usize = core::mem::size_of::<u32>();
         self.check_remaining(SIZE);
@@ -125,6 +133,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_i32_le(&mut self, val: i32) {
         const SIZE: usize = core::mem::size_of::<i32>();
         self.check_remaining(SIZE);
@@ -134,6 +143,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_u64_le(&mut self, val: u64) {
         const SIZE: usize = core::mem::size_of::<u64>();
         self.check_remaining(SIZE);
@@ -143,6 +153,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_i64_le(&mut self, val: i64) {
         const SIZE: usize = core::mem::size_of::<i64>();
         self.check_remaining(SIZE);
@@ -152,6 +163,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_f32_le(&mut self, val: f32) {
         const SIZE: usize = core::mem::size_of::<f32>();
         self.check_remaining(SIZE);
@@ -161,6 +173,7 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    #[inline]
     pub fn put_f64_le(&mut self, val: f64) {
         const SIZE: usize = core::mem::size_of::<f64>();
         self.check_remaining(SIZE);


### PR DESCRIPTION
Hi! While playing around with the library, I noticed that the routines for serialising and deserialising messages are compiled to pretty big functions. So, I tried to optimised them a bit for a size, which is handy for embedded devices.

First, I added inline hints to the `Bytes` struct to push a compiler to optimising these function calls to simple instructions. The `<MavlinkMessage>::ser` always ensures that the buffer has the correct size, the compiler strips out the length checks and panics in all `Bytes` methods, reducing the code size.

Second, I added a check for a buffer size in the `<MavlinkMessage>::deser` method. This hints a compiler that the buffer is always of the correct size, so the subsequent checks in the `BytesMut` method can also be optimised away. And they are optimised even without the inline hints.

I measured the result using cargo bloat on amd64 architecture. Here is the before result for one of the tests:

```
$ cargo bloat --release --filter 'mavlink::common' --features common --test  tcp_loopback_tests 2> /dev/null
File .text     Size   Crate Name
0.3%  2.1%  17.4KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::parse
0.0%  0.4%   3.0KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::ser
0.0%  0.3%   2.4KiB mavlink <mavlink::common::ONBOARD_COMPUTER_STATUS_DATA as mavlink_core::MessageData>::deser
0.0%  0.3%   2.2KiB mavlink <mavlink::common::GIMBAL_DEVICE_INFORMATION_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.8KiB mavlink <mavlink::common::TRAJECTORY_REPRESENTATION_WAYPOINTS_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.8KiB mavlink <mavlink::common::GPS_STATUS_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.8KiB mavlink <mavlink::common::ODOMETRY_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.7KiB mavlink <mavlink::common::LOCAL_POSITION_NED_COV_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.7KiB mavlink <mavlink::common::CELLULAR_CONFIG_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.6KiB mavlink <mavlink::common::SMART_BATTERY_INFO_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.3KiB mavlink mavlink::common::_IMPL_NUM_FromPrimitive_FOR_MavCmd::<impl num_traits::cast::FromPrimitive for mavlink::common::MavCmd>::from_i64
0.0%  0.2%   1.3KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::message_id
0.0%  0.2%   1.3KiB mavlink <mavlink::common::GLOBAL_POSITION_INT_COV_DATA as mavlink_core::MessageData>::deser
0.0%  0.2%   1.3KiB mavlink <mavlink::common::GIMBAL_DEVICE_INFORMATION_DATA as mavlink_core::MessageData>::ser
0.0%  0.2%   1.2KiB mavlink <mavlink::common::ONBOARD_COMPUTER_STATUS_DATA as mavlink_core::MessageData>::ser
0.0%  0.1%   1.2KiB mavlink <mavlink::common::CAMERA_INFORMATION_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%   1.2KiB mavlink <mavlink::common::GPS_STATUS_DATA as mavlink_core::MessageData>::ser
0.0%  0.1%   1.1KiB mavlink <mavlink::common::OPEN_DRONE_ID_ARM_STATUS_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%   1.1KiB mavlink <mavlink::common::STATUSTEXT_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%   1.0KiB mavlink <mavlink::common::OPEN_DRONE_ID_LOCATION_DATA as mavlink_core::MessageData>::deser
2.1% 15.8% 129.5KiB         And 399 smaller methods. Use -n N to show more.
2.9% 21.6% 176.8KiB         filtered data size, the file size is 6.0MiB
```

And here is the result after all optimisations:

```
$ cargo bloat --release --filter 'mavlink::common' --features common --test  tcp_loopback_tests 2> /dev/null
File .text    Size   Crate Name
0.3%  2.7% 19.3KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::parse
0.0%  0.2%  1.7KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::ser
0.0%  0.2%  1.3KiB mavlink mavlink::common::_IMPL_NUM_FromPrimitive_FOR_MavCmd::<impl num_traits::cast::FromPrimitive for mavlink::common::MavCmd>::from_i64
0.0%  0.2%  1.3KiB mavlink <mavlink::common::MavMessage as mavlink_core::Message>::message_id
0.0%  0.1%    622B mavlink <mavlink::common::MavMessage as mavlink_core::Message>::extra_crc
0.0%  0.1%    609B mavlink <mavlink::common::DISTANCE_SENSOR_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%    444B mavlink <mavlink::common::ONBOARD_COMPUTER_STATUS_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%    430B mavlink <mavlink::common::ODOMETRY_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%    399B mavlink <mavlink::common::OPEN_DRONE_ID_LOCATION_DATA as mavlink_core::MessageData>::deser
0.0%  0.1%    373B mavlink <mavlink::common::TRAJECTORY_REPRESENTATION_WAYPOINTS_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    338B mavlink <mavlink::common::TUNNEL_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    318B mavlink <mavlink::common::SERIAL_CONTROL_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    312B mavlink <mavlink::common::VIDEO_STREAM_INFORMATION_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    293B mavlink <mavlink::common::OPEN_DRONE_ID_SYSTEM_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    286B mavlink <mavlink::common::PARAM_EXT_ACK_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    286B mavlink <mavlink::common::CAMERA_INFORMATION_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    278B mavlink <mavlink::common::GLOBAL_POSITION_INT_COV_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    265B mavlink <mavlink::common::UTM_GLOBAL_POSITION_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    262B mavlink <mavlink::common::LOCAL_POSITION_NED_COV_DATA as mavlink_core::MessageData>::deser
0.0%  0.0%    261B mavlink <mavlink::common::HIL_CONTROLS_DATA as mavlink_core::MessageData>::deser
0.6%  5.4% 38.1KiB         And 305 smaller methods. Use -n N to show more.
1.1%  9.6% 67.5KiB         filtered data size, the file size is 5.8MiB
```

I also measured the code size for `thumbv7em-none-eabihf` on a small STM32 and the effect is much the same, so I'm sure that this will be useful for other targets as well.