### PR TITLE
Emit extensions

### DIFF
--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -28,3 +28,5 @@ anstyle-parse = { version = "=0.2.1", optional=true }
 
 [features]
 cli = ["dep:clap", "dep:clap_lex", "dep:clap_builder", "dep:anstyle", "dep:anstyle-query", "dep:anstyle-parse"]
+emit-extensions = []
+emit-description = []

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mavlink-bindgen"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Library used by rust-mavlink."

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mavlink-core"
-version = "0.13.1"
+version = "0.13.2"
 authors = [
     "Todd Stellanova",
     "Michal Podhradsky",

--- a/mavlink-core/src/utils.rs
+++ b/mavlink-core/src/utils.rs
@@ -22,7 +22,7 @@ pub fn remove_trailing_zeroes(data: &[u8]) -> usize {
 /// `MavType`s. This is only needed because rust doesn't currently implement `Default` for arrays
 /// of all sizes. In particular this trait is only ever used when the "serde" feature is enabled.
 /// For more information, check out [this issue](https://users.rust-lang.org/t/issue-for-derives-for-arrays-greater-than-size-32/59055/3).
-pub(crate) trait RustDefault: Copy {
+pub trait RustDefault: Copy {
     fn rust_default() -> Self;
 }
 

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -64,7 +64,6 @@ serde_arrays = { version = "0.1.0", optional = true }
 "ualberta" = ["common"]
 "uavionix" = ["common"]
 "icarous" = []
-"storm32" = []
 "common" = []
 "cubepilot" = ["common"]
 
@@ -85,7 +84,6 @@ serde_arrays = { version = "0.1.0", optional = true }
     "icarous",
     "common",
     "cubepilot",
-    "storm32",
 ]
 
 "format-generated-code" = []

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -49,6 +49,7 @@ serde_arrays = { version = "0.1.0", optional = true }
     "uavionix",
     "avssuas",
     "cubepilot",
+    "storm32",
 ]
 "ardupilotmega" = ["common", "icarous", "uavionix"]
 "asluav" = ["common"]
@@ -64,6 +65,7 @@ serde_arrays = { version = "0.1.0", optional = true }
 "ualberta" = ["common"]
 "uavionix" = ["common"]
 "icarous" = []
+"storm32" = []
 "common" = []
 "cubepilot" = ["common"]
 
@@ -84,6 +86,7 @@ serde_arrays = { version = "0.1.0", optional = true }
     "icarous",
     "common",
     "cubepilot",
+    "storm32",
 ]
 
 "format-generated-code" = []

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "mavlink"
-version = "0.13.1"
+version = "0.13.2"
 authors = [
     "Todd Stellanova",
     "Michal Podhradsky",

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -49,7 +49,6 @@ serde_arrays = { version = "0.1.0", optional = true }
     "uavionix",
     "avssuas",
     "cubepilot",
-    "storm32",
 ]
 "ardupilotmega" = ["common", "icarous", "uavionix"]
 "asluav" = ["common"]

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -87,8 +87,8 @@ serde_arrays = { version = "0.1.0", optional = true }
 ]
 
 "format-generated-code" = []
-"emit-description" = []
-"emit-extensions" = []
+"emit-description" = ["mavlink-bindgen/emit-description"]
+"emit-extensions" = ["mavlink-bindgen/emit-extensions"]
 "std" = ["mavlink-core/std"]
 "udp" = ["mavlink-core/udp"]
 "tcp" = ["mavlink-core/tcp"]

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -3,3 +3,7 @@
 include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 
 pub use mavlink_core::*;
+
+#[cfg(feature = "emit-extensions")]
+#[allow(unused_imports)]
+pub(crate) use mavlink_core::utils::RustDefault;


### PR DESCRIPTION
Fixes emit-extensions and emit-descriptions features not being used by mavlink-bindgen (#246).
This requires a (none breaking) bump in version since fixes in the mavlink crate require newer versions of mavlink-bindgen/mavlink-core crates.
To ensure test work this required adding the path specifications for the dependencies within this crate.

Fixes missing storm32 dialect feature.
