### PR TITLE
mavlink-codegen documentaion

### DIFF
--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.13.1"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Library used by rust-mavlink."
-readme = "../README.md"
+readme = "README.md"
+repository = "https://github.com/mavlink/rust-mavlink"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/mavlink-bindgen/README.md
+++ b/mavlink-bindgen/README.md
@@ -1,52 +1,54 @@
-# rust-mavlink
+# mavlink-bindgen
 
 [![Build status](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml/badge.svg)](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml)
-
 [![Crate info](https://img.shields.io/crates/v/mavlink-bindgen.svg)](https://crates.io/crates/mavlink-bindgen)
 [![Documentation](https://docs.rs/mavlink-bindgen/badge.svg)](https://docs.rs/mavlink-bindgen)
 
-Library and CLI for code generator of the Rust implementation of the [MAVLink](https://mavlink.io/en) UAV messaging protocol.
+Library and CLI for generating code for the Rust implementation of the [MAVLink](https://mavlink.io/en) UAV messaging protocol.
 
-`mavlink-bindgen` can be used to create MAVLink bindings for Rust. This is used from `build.rs` in the [mavlink](https://crates.io/crates/mavlink) crate to create bindings from the standard MAVLink dialects in https://github.com/mavlink/mavlink. 
+`mavlink-bindgen` can be used to create MAVLink bindings for Rust. This is used from `build.rs` in the [mavlink](https://crates.io/crates/mavlink) crate to create bindings from the standard MAVLink dialects in <https://github.com/mavlink/mavlink>.
 
 ## Usage
 
-`mavlink-bindgen` can be used as a code generator from `build.rs` as done is the `mavlink` crate for a custom MAVLink dialect or as a CLI tool to generate rust binding from XML dialect definitions. The generated code will depend on the [mavlink-core](https://crates.io/crates/mavlink-core) crate in both use cases.
+`mavlink-bindgen` can be used as a code generator from `build.rs` as done is the `mavlink` crate for a custom MAVLink dialect or as a CLI tool to generate rust binding from XML dialect definitions. The generated code will depend on the [mavlink-core](https://crates.io/crates/mavlink-core) crate in both use cases. Each dialect generated will be locked behind a feature flag of the same name, that must be enabled when using the generated code.
 
 ### CLI
 
-Build using cargo with `cli` feature enabled:
+Build the binary using cargo with `cli` feature enabled:
 
 ```shell
+cd mavlink-bindgen
 cargo build --features cli
 ```
 
-Alternatively you can build and install `mavlink-bindgen` to you locally installed crates:
+Alternatively you can build and install `mavlink-bindgen` to your locally installed crates:
 
 ```shell
 cargo install mavlink-bindgen --features cli
 ```  
 
-Generate code using the resulting binary:
+To generate code using the resulting binary:
 
 ```shell
 mavlink-bindgen --format-generated-code message_definitions mavlink_dialects
 ```
 
-The full options are shown below.
+The full command line options are shown below.
 
 ```shell
 Usage: mavlink-bindgen [OPTIONS] <DEFINITIONS_DIR> <DESTINATION_DIR>
 
 Arguments:
   <DEFINITIONS_DIR>  Path to the directory containing the MAVLink dialect definitions
-  <DESTINATION_DIR>  Path to the directory where the code is generated into
+  <DESTINATION_DIR>  Path to the directory where the code is generated into, must already exist
 
 Options:
       --format-generated-code      format code generated code
       --emit-cargo-build-messages  prints cargo build message indicating when the code has to be rebuild
   -h, --help                       Print help
 ```
+
+The output dir will contain a `mod.rs` file with each dialect in its own file locked behind a feature flag.
 
 ### Library as build dependency
 
@@ -91,4 +93,6 @@ include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 pub use mavlink_core::*;
 ```
 
-This approach is used by the mavlink crate see its build script for an example.
+Since each dialect is locked behind a feature flag these need to be enabled for the dialects to become available when using the generated code.
+
+This approach is used by the `mavlink` crate see its build script for an example.

--- a/mavlink-bindgen/README.md
+++ b/mavlink-bindgen/README.md
@@ -1,0 +1,94 @@
+# rust-mavlink
+
+[![Build status](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml/badge.svg)](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml)
+
+[![Crate info](https://img.shields.io/crates/v/mavlink-bindgen.svg)](https://crates.io/crates/mavlink-bindgen)
+[![Documentation](https://docs.rs/mavlink-bindgen/badge.svg)](https://docs.rs/mavlink-bindgen)
+
+Library and CLI for code generator of the Rust implementation of the [MAVLink](https://mavlink.io/en) UAV messaging protocol.
+
+`mavlink-bindgen` can be used to create MAVLink bindings for Rust. This is used from `build.rs` in the [mavlink](https://crates.io/crates/mavlink) crate to create bindings from the standard MAVLink dialects in https://github.com/mavlink/mavlink. 
+
+## Usage
+
+`mavlink-bindgen` can be used as a code generator from `build.rs` as done is the `mavlink` crate for a custom MAVLink dialect or as a CLI tool to generate rust binding from XML dialect definitions. The generated code will depend on the [mavlink-core](https://crates.io/crates/mavlink-core) crate in both use cases.
+
+### CLI
+
+Build using cargo with `cli` feature enabled:
+
+```shell
+cargo build --features cli
+```
+
+Alternatively you can build and install `mavlink-bindgen` to you locally installed crates:
+
+```shell
+cargo install mavlink-bindgen --features cli
+```  
+
+Generate code using the resulting binary:
+
+```shell
+mavlink-bindgen --format-generated-code message_definitions mavlink_dialects
+```
+
+The full options are shown below.
+
+```shell
+Usage: mavlink-bindgen [OPTIONS] <DEFINITIONS_DIR> <DESTINATION_DIR>
+
+Arguments:
+  <DEFINITIONS_DIR>  Path to the directory containing the MAVLink dialect definitions
+  <DESTINATION_DIR>  Path to the directory where the code is generated into
+
+Options:
+      --format-generated-code      format code generated code
+      --emit-cargo-build-messages  prints cargo build message indicating when the code has to be rebuild
+  -h, --help                       Print help
+```
+
+### Library as build dependency
+
+Add to your Cargo.toml:
+
+```toml
+mavlink-bindgen = "0.13.1"
+```
+
+Add a `build/main.rs` or `build.rs` to your project if it does not already exist. Then add the following to the `main` function to generate the code:
+
+```rs
+let out_dir = env::var("OUT_DIR").unwrap();
+let result = match mavlink_bindgen::generate(definitions_dir, out_dir) {
+    Ok(r) => r,
+    Err(e) => {
+        eprintln!("{e}");
+        return ExitCode::FAILURE;
+    }
+};
+```
+
+If the generated code should be formated use
+
+```rs
+    mavlink_bindgen::format_generated_code(&result);
+```
+
+To tell cargo when to regenerate code from the definitions use:
+
+```rs
+    mavlink_bindgen::emit_cargo_build_messages(&result);
+```
+
+Finally include the generated code into the `lib.rs` or `main.rs` :
+
+```rs
+#![cfg_attr(not(feature = "std"), no_std)]
+// include generate definitions
+include!(concat!(env!("OUT_DIR"), "/mod.rs"));
+
+pub use mavlink_core::*;
+```
+
+This approach is used by the mavlink crate see its build script for an example.

--- a/mavlink-bindgen/src/cli.rs
+++ b/mavlink-bindgen/src/cli.rs
@@ -4,11 +4,16 @@ use clap::Parser;
 use mavlink_bindgen::{emit_cargo_build_messages, format_generated_code, generate, BindGenError};
 
 #[derive(Parser)]
+/// Generate Rust bindings from MAVLink message dialect XML files.
 struct Cli {
+    /// Path to the directory containing the MAVLink dialect definitions.
     definitions_dir: PathBuf,
+    /// Path to the directory where the code is generated into, must already exist.
     destination_dir: PathBuf,
+    /// format code generated code
     #[arg(long)]
     format_generated_code: bool,
+    /// prints cargo build messages indicating when the code has to be rebuild
     #[arg(long)]
     emit_cargo_build_messages: bool,
 }

--- a/mavlink-bindgen/src/error.rs
+++ b/mavlink-bindgen/src/error.rs
@@ -8,7 +8,7 @@ pub enum BindGenError {
         source: std::io::Error,
         path: std::path::PathBuf,
     },
-    /// Represents a failure to read the MAVLink definitions directory.
+    /// Represents a failure to read a MAVLink definition file.
     #[error("Could not read definition file {path}: {source}")]
     CouldNotReadDefinitionFile {
         source: std::io::Error,

--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -23,6 +23,9 @@ pub struct GeneratedBindings {
     pub mod_rs: PathBuf,
 }
 
+/// Generate Rust MAVLink dialect binding for dialects present in `definitions_dir` into `destination_dir`.
+///
+/// If successful returns paths of generated bindings linked to their dialect definitions files.
 pub fn generate<P1: AsRef<Path>, P2: AsRef<Path>>(
     definitions_dir: P1,
     destination_dir: P2,
@@ -99,6 +102,7 @@ fn _generate(
     }
 }
 
+/// Formats generated code using `rustfmt`.
 pub fn format_generated_code(result: &GeneratedBindings) {
     if let Err(error) = Command::new("rustfmt")
         .args(
@@ -114,6 +118,7 @@ pub fn format_generated_code(result: &GeneratedBindings) {
     }
 }
 
+/// Prints definitions for cargo that describe which files the generated code depends on, indicating when it has to be regenerated.
 pub fn emit_cargo_build_messages(result: &GeneratedBindings) {
     for binding in &result.bindings {
         // Re-run build if definition file changes


### PR DESCRIPTION
- Adds README.md to mavlink-bindgen, that describes how to use this crate to generate code
- Adds documentation to publicly exposed function from mavlink-bingens lib.rs
- Add link to the repository for crates.io
- Add doc for CLI options/arguments
- Fix doc of error CouldNotReadDefinitionFile