### PR TITLE
Update MSRV check to account for features

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,22 +48,19 @@ jobs:
   msrv:
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        signing: ["", "--features signing"]
+      matrix:
+        features: ["", "--features serde,tokio-1", "--features signing"]
     steps:
       - uses: actions/checkout@master
+      - name: Get MSRV from Cargo.toml
+        run: |
+          MSRV=$(grep 'rust-version' Cargo.toml | sed 's/.*= *"\(.*\)".*/\1/')
+          echo "MSRV=$MSRV" >> $GITHUB_ENV
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.65.0
-      - uses: actions-rs/cargo@v1
-        with:
-          command: install
-          args: cross --locked
-      - uses: actions-rs/cargo@v1
-        with:
-          use-cross: true
-          command: check
-          args: --all --all-targets ${{ matrix.signing }}
+          toolchain: ${{ env.MSRV }}
+      - uses: taiki-e/install-action@cargo-no-dev-deps
+      - run: cargo no-dev-deps check --all --all-targets ${{ matrix.features }}
 
   build:
     needs: [formatting, linting, internal-tests, mavlink-dump, msrv]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ byteorder = { version = "1.3.4", default-features = false }
 
 [workspace.package]
 edition = "2021"
+rust-version = "1.70.0"

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -6,6 +6,7 @@ license = "MIT/Apache-2.0"
 description = "Library used by rust-mavlink."
 readme = "README.md"
 repository = "https://github.com/mavlink/rust-mavlink"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mavlink/rust-mavlink"
 edition.workspace = true
-rust-version = "1.65.0"
+rust-version.workspace = true
 
 [dependencies]
 crc-any = { workspace = true, default-features = false }

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -16,7 +16,7 @@ readme = "../README.md"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/mavlink/rust-mavlink"
 edition.workspace = true
-rust-version = "1.65.0"
+rust-version.workspace = true
 
 [build-dependencies]
 mavlink-bindgen = { path = "../mavlink-bindgen", default-features = false }


### PR DESCRIPTION
updates the MSRV check to account for the `serde` and `tokio-1` features

- use cargo-no-dev-deps to ensure that dev dependencies don't impact the MSRV
- checks a matrix of features for the MSRV

note that this would be trivial to modify so that that the matrix had a different MSRV for each feature, depending on the chosen policy of this repo. See https://github.com/mavlink/rust-mavlink/issues/258