### PR TITLE
doc_auto_cfg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,9 +126,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@nightly
     - name: Build docs
-      run: cargo doc
+      run: cargo doc --features "default all-dialects emit-description emit-extensions format-generated-code tokio-1 signing" 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       if: ${{ github.ref == 'refs/heads/master' }}

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -19,7 +19,7 @@
 //! feature without also using the `uavionix` and `icarous` features.
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(any(docsrs, doc), feature(doc_auto_cfg))]
+#![cfg_attr(all(any(docsrs, doc), not(doctest)), feature(doc_auto_cfg))]
 #![deny(clippy::all)]
 #![warn(clippy::use_self)]
 

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -19,6 +19,7 @@
 //! feature without also using the `uavionix` and `icarous` features.
 //!
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(any(docsrs, doc), feature(doc_auto_cfg))]
 #![deny(clippy::all)]
 #![warn(clippy::use_self)]
 

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(any(docsrs, doc), feature(doc_auto_cfg))]
 // include generate definitions
 include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(any(docsrs, doc), feature(doc_auto_cfg))]
+#![cfg_attr(all(any(docsrs, doc), not(doctest)), feature(doc_auto_cfg))]
 // include generate definitions
 include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 


### PR DESCRIPTION
This enables the `doc_auto_cfg` feature that allows to show which components depend on which features in the documentation (example: [tokio BufReader doc](https://docs.rs/tokio/latest/tokio/io/struct.BufReader.html)). This will only be enabled on `cargo doc` and docs.rs.
Since is a nightly feature switch the doc test to nightly too.
Also adds all features that are enabled for docs.rs for the doc test.