### PR TITLE
async connections

### DIFF
--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -26,7 +26,7 @@ embedded-io-async = { version = "0.6.1", optional = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
 serial = { version = "0.4", optional = true }
-tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs", ], optional = true }
+tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs"], optional = true }
 sha2 = { version = "0.10", optional = true }
 async-trait = { version = "0.1.18", optional = true }
 
@@ -46,4 +46,4 @@ async-trait = { version = "0.1.18", optional = true }
 default = ["std", "tcp", "udp", "direct-serial", "serde"]
 
 [dev-dependencies]
-tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs","macros", "rt" ] }
+tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs", "macros", "rt"] }

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -46,5 +46,4 @@ async-trait = { version = "0.1.18", optional = true }
 default = ["std", "tcp", "udp", "direct-serial", "serde"]
 
 [dev-dependencies]
-# 1.39 tokio macros seems to be currently broken
-tokio = { version = "1.0, <=1.38", default-features = false, features = ["io-util", "net", "sync", "fs","macros", "rt" ] }
+tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs","macros", "rt" ] }

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -26,8 +26,9 @@ embedded-io-async = { version = "0.6.1", optional = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.1.0", optional = true }
 serial = { version = "0.4", optional = true }
-tokio = { version = "1.0", default-features = false, features = ["io-util"], optional = true }
+tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs", ], optional = true }
 sha2 = { version = "0.10", optional = true }
+async-trait = { version = "0.1.18", optional = true }
 
 [features]
 "std" = ["byteorder/std"]
@@ -40,6 +41,10 @@ sha2 = { version = "0.10", optional = true }
 "embedded" = ["dep:embedded-io", "dep:embedded-io-async"]
 "embedded-hal-02" = ["dep:nb", "dep:embedded-hal-02"]
 "serde" = ["dep:serde", "dep:serde_arrays"]
-"tokio-1" = ["dep:tokio"]
+"tokio-1" = ["dep:tokio", "dep:async-trait"]
 "signing" = ["dep:sha2"]
 default = ["std", "tcp", "udp", "direct-serial", "serde"]
+
+[dev-dependencies]
+# 1.39 tokio macros seems to be currently broken
+tokio = { version = "1.0, <=1.38", default-features = false, features = ["io-util", "net", "sync", "fs","macros", "rt" ] }

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -1,0 +1,83 @@
+use core::ops::DerefMut;
+
+use super::AsyncMavConnection;
+use crate::error::{MessageReadError, MessageWriteError};
+
+use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Message};
+
+use tokio::fs::File;
+use tokio::io;
+use tokio::sync::Mutex;
+
+#[cfg(not(feature = "signing"))]
+use crate::read_versioned_msg_async;
+
+#[cfg(feature = "signing")]
+use crate::{read_versioned_msg_async_signed, SigningConfig, SigningData};
+
+/// File MAVLINK connection
+
+pub async fn open(file_path: &str) -> io::Result<AsyncFileConnection> {
+    let file = File::open(file_path).await?;
+    Ok(AsyncFileConnection {
+        file: Mutex::new(AsyncPeekReader::new(file)),
+        protocol_version: MavlinkVersion::V2,
+        #[cfg(feature = "signing")]
+        signing_data: None,
+    })
+}
+
+pub struct AsyncFileConnection {
+    file: Mutex<AsyncPeekReader<File>>,
+    protocol_version: MavlinkVersion,
+
+    #[cfg(feature = "signing")]
+    signing_data: Option<SigningData>,
+}
+
+#[async_trait::async_trait]
+impl<M: Message + Sync> AsyncMavConnection<M> for AsyncFileConnection {
+    async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
+        let mut file = self.file.lock().await;
+
+        loop {
+            #[cfg(not(feature = "signing"))]
+            let result = read_versioned_msg_async(file.deref_mut(), self.protocol_version).await;
+            #[cfg(feature = "signing")]
+            let result = read_versioned_msg_async_signed(
+                file.deref_mut(),
+                self.protocol_version,
+                self.signing_data.as_ref(),
+            )
+            .await;
+            match result {
+                ok @ Ok(..) => {
+                    return ok;
+                }
+                Err(MessageReadError::Io(e)) => {
+                    if e.kind() == io::ErrorKind::UnexpectedEof {
+                        return Err(MessageReadError::Io(e));
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn send(&self, _header: &MavHeader, _data: &M) -> Result<usize, MessageWriteError> {
+        Ok(0)
+    }
+
+    fn set_protocol_version(&mut self, version: MavlinkVersion) {
+        self.protocol_version = version;
+    }
+
+    fn get_protocol_version(&self) -> MavlinkVersion {
+        self.protocol_version
+    }
+
+    #[cfg(feature = "signing")]
+    fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
+        self.signing_data = signing_data.map(SigningData::from_config)
+    }
+}

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -36,7 +36,7 @@ pub struct AsyncFileConnection {
 }
 
 #[async_trait::async_trait]
-impl<M: Message + Sync> AsyncMavConnection<M> for AsyncFileConnection {
+impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncFileConnection {
     async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
         let mut file = self.file.lock().await;
 

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -1,3 +1,5 @@
+//! Async File MAVLINK connection
+
 use core::ops::DerefMut;
 
 use super::AsyncMavConnection;
@@ -14,8 +16,6 @@ use crate::read_versioned_msg_async;
 
 #[cfg(feature = "signing")]
 use crate::{read_versioned_msg_async_signed, SigningConfig, SigningData};
-
-/// File MAVLINK connection
 
 pub async fn open(file_path: &str) -> io::Result<AsyncFileConnection> {
     let file = File::open(file_path).await?;

--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -15,7 +15,7 @@ use crate::SigningConfig;
 
 /// An async MAVLink connection
 #[async_trait::async_trait]
-pub trait AsyncMavConnection<M: Message + Sync> {
+pub trait AsyncMavConnection<M: Message + Sync + Send> {
     /// Receive a mavlink message.
     ///
     /// Wait until a valid frame is received, ignoring invalid messages.

--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -1,0 +1,137 @@
+use tokio::io;
+
+use crate::{MavFrame, MavHeader, MavlinkVersion, Message};
+
+#[cfg(feature = "tcp")]
+mod tcp;
+
+#[cfg(feature = "udp")]
+mod udp;
+
+mod file;
+
+#[cfg(feature = "signing")]
+use crate::SigningConfig;
+
+/// A MAVLink connection
+#[async_trait::async_trait]
+pub trait AsyncMavConnection<M: Message + Sync> {
+    /// Receive a mavlink message.
+    ///
+    /// Blocks until a valid frame is received, ignoring invalid messages.
+    async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
+
+    /// Send a mavlink message
+    async fn send(
+        &self,
+        header: &MavHeader,
+        data: &M,
+    ) -> Result<usize, crate::error::MessageWriteError>;
+
+    fn set_protocol_version(&mut self, version: MavlinkVersion);
+    fn get_protocol_version(&self) -> MavlinkVersion;
+
+    /// Write whole frame
+    async fn send_frame(
+        &self,
+        frame: &MavFrame<M>,
+    ) -> Result<usize, crate::error::MessageWriteError> {
+        self.send(&frame.header, &frame.msg).await
+    }
+
+    /// Read whole frame
+    async fn recv_frame(&self) -> Result<MavFrame<M>, crate::error::MessageReadError> {
+        let (header, msg) = self.recv().await?;
+        let protocol_version = self.get_protocol_version();
+        Ok(MavFrame {
+            header,
+            msg,
+            protocol_version,
+        })
+    }
+
+    /// Send a message with default header
+    async fn send_default(&self, data: &M) -> Result<usize, crate::error::MessageWriteError> {
+        let header = MavHeader::default();
+        self.send(&header, data).await
+    }
+
+    /// Setup secret key used for message signing, or disable message signing
+    #[cfg(feature = "signing")]
+    fn setup_signing(&mut self, signing_data: Option<SigningConfig>);
+}
+
+/// Connect to a MAVLink node by address string.
+///
+/// The address must be in one of the following formats:
+///
+///  * `tcpin:<addr>:<port>` to create a TCP server, listening for incoming connections
+///  * `tcpout:<addr>:<port>` to create a TCP client
+///  * `udpin:<addr>:<port>` to create a UDP server, listening for incoming packets
+///  * `udpout:<addr>:<port>` to create a UDP client
+///  * `udpbcast:<addr>:<port>` to create a UDP broadcast
+///  *  NOT `serial:<port>:<baudrate>` to create a serial connection
+///  * `file:<path>` to extract file data
+///
+/// The type of the connection is determined at runtime based on the address type, so the
+/// connection is returned as a trait object.
+// TODO only reason this has to be send is udp serve
+pub async fn connect_async<M: Message + Sync + Send>(
+    address: &str,
+) -> io::Result<Box<dyn AsyncMavConnection<M> + Sync + Send>> {
+    let protocol_err = Err(io::Error::new(
+        io::ErrorKind::AddrNotAvailable,
+        "Protocol unsupported",
+    ));
+
+    if cfg!(feature = "tcp") && address.starts_with("tcp") {
+        #[cfg(feature = "tcp")]
+        {
+            tcp::select_protocol(address).await
+        }
+        #[cfg(not(feature = "tcp"))]
+        {
+            protocol_err
+        }
+    } else if cfg!(feature = "udp") && address.starts_with("udp") {
+        #[cfg(feature = "udp")]
+        {
+            udp::select_protocol(address).await
+        }
+        #[cfg(not(feature = "udp"))]
+        {
+            protocol_err
+        }
+    } else if cfg!(feature = "direct-serial") && address.starts_with("serial:") {
+        #[cfg(feature = "direct-serial")]
+        {
+            todo!()
+            //Ok(Box::new(direct_serial::open(&address["serial:".len()..])?))
+        }
+        #[cfg(not(feature = "direct-serial"))]
+        {
+            protocol_err
+        }
+    } else if address.starts_with("file") {
+        Ok(Box::new(file::open(&address["file:".len()..]).await?))
+    } else {
+        protocol_err
+    }
+}
+
+// TODO remove this ?
+/// Returns the socket address for the given address.
+pub(crate) fn get_socket_addr<T: std::net::ToSocketAddrs>(
+    address: T,
+) -> Result<std::net::SocketAddr, io::Error> {
+    let addr = match address.to_socket_addrs()?.next() {
+        Some(addr) => addr,
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Host address lookup failed",
+            ));
+        }
+    };
+    Ok(addr)
+}

--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -18,7 +18,7 @@ use crate::SigningConfig;
 pub trait AsyncMavConnection<M: Message + Sync + Send> {
     /// Receive a mavlink message.
     ///
-    /// Wait until a valid frame is received, ignoring invalid messages.
+    /// Yield until a valid frame is received, ignoring invalid messages.
     async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
 
     /// Send a mavlink message

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -17,7 +17,7 @@ use crate::{
 
 /// TCP MAVLink connection
 
-pub async fn select_protocol<M: Message + Sync>(
+pub async fn select_protocol<M: Message + Sync + Send>(
     address: &str,
 ) -> io::Result<Box<dyn AsyncMavConnection<M> + Sync + Send>> {
     let connection = if let Some(address) = address.strip_prefix("tcpout:") {
@@ -97,7 +97,7 @@ struct TcpWrite {
 }
 
 #[async_trait::async_trait]
-impl<M: Message + Sync> AsyncMavConnection<M> for TcpConnection {
+impl<M: Message + Sync + Send> AsyncMavConnection<M> for TcpConnection {
     async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
         let mut reader = self.reader.lock().await;
         #[cfg(not(feature = "signing"))]

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -1,3 +1,5 @@
+//! Async TCP MAVLink connection
+
 use super::{get_socket_addr, AsyncMavConnection};
 use crate::async_peek_reader::AsyncPeekReader;
 use crate::{MavHeader, MavlinkVersion, Message};
@@ -14,8 +16,6 @@ use crate::{read_versioned_msg_async, write_versioned_msg_async};
 use crate::{
     read_versioned_msg_async_signed, write_versioned_msg_async_signed, SigningConfig, SigningData,
 };
-
-/// TCP MAVLink connection
 
 pub async fn select_protocol<M: Message + Sync + Send>(
     address: &str,
@@ -57,7 +57,7 @@ pub async fn tcpin<T: std::net::ToSocketAddrs>(address: T) -> io::Result<TcpConn
     let addr = get_socket_addr(address)?;
     let listener = TcpListener::bind(addr).await?;
 
-    //For now we only accept one incoming stream: this blocks until we get one
+    //For now we only accept one incoming stream: this yields until we get one
     match listener.accept().await {
         Ok((socket, _)) => {
             let (reader, writer) = socket.into_split();

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -1,0 +1,156 @@
+use super::{get_socket_addr, AsyncMavConnection};
+use crate::async_peek_reader::AsyncPeekReader;
+use crate::{MavHeader, MavlinkVersion, Message};
+
+use core::ops::DerefMut;
+use tokio::io;
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Mutex;
+
+#[cfg(not(feature = "signing"))]
+use crate::{read_versioned_msg_async, write_versioned_msg_async};
+#[cfg(feature = "signing")]
+use crate::{
+    read_versioned_msg_async_signed, write_versioned_msg_async_signed, SigningConfig, SigningData,
+};
+
+/// TCP MAVLink connection
+
+pub async fn select_protocol<M: Message + Sync>(
+    address: &str,
+) -> io::Result<Box<dyn AsyncMavConnection<M> + Sync + Send>> {
+    let connection = if let Some(address) = address.strip_prefix("tcpout:") {
+        tcpout(address).await
+    } else if let Some(address) = address.strip_prefix("tcpin:") {
+        tcpin(address).await
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "Protocol unsupported",
+        ))
+    };
+
+    Ok(Box::new(connection?))
+}
+
+pub async fn tcpout<T: std::net::ToSocketAddrs>(address: T) -> io::Result<TcpConnection> {
+    let addr = get_socket_addr(address)?;
+
+    let socket = TcpStream::connect(addr).await?;
+
+    let (reader, writer) = socket.into_split();
+
+    Ok(TcpConnection {
+        reader: Mutex::new(AsyncPeekReader::new(reader)),
+        writer: Mutex::new(TcpWrite {
+            socket: writer,
+            sequence: 0,
+        }),
+        protocol_version: MavlinkVersion::V2,
+        #[cfg(feature = "signing")]
+        signing_data: None,
+    })
+}
+
+pub async fn tcpin<T: std::net::ToSocketAddrs>(address: T) -> io::Result<TcpConnection> {
+    let addr = get_socket_addr(address)?;
+    let listener = TcpListener::bind(addr).await?;
+
+    //For now we only accept one incoming stream: this blocks until we get one
+    match listener.accept().await {
+        Ok((socket, _)) => {
+            let (reader, writer) = socket.into_split();
+            return Ok(TcpConnection {
+                reader: Mutex::new(AsyncPeekReader::new(reader)),
+                writer: Mutex::new(TcpWrite {
+                    socket: writer,
+                    sequence: 0,
+                }),
+                protocol_version: MavlinkVersion::V2,
+                #[cfg(feature = "signing")]
+                signing_data: None,
+            });
+        }
+        Err(e) => {
+            //TODO don't println in lib
+            println!("listener err: {e}");
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotConnected,
+        "No incoming connections!",
+    ))
+}
+
+pub struct TcpConnection {
+    reader: Mutex<AsyncPeekReader<OwnedReadHalf>>,
+    writer: Mutex<TcpWrite>,
+    protocol_version: MavlinkVersion,
+    #[cfg(feature = "signing")]
+    signing_data: Option<SigningData>,
+}
+
+struct TcpWrite {
+    socket: OwnedWriteHalf,
+    sequence: u8,
+}
+
+#[async_trait::async_trait]
+impl<M: Message + Sync> AsyncMavConnection<M> for TcpConnection {
+    async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().await;
+        #[cfg(not(feature = "signing"))]
+        let result = read_versioned_msg_async(reader.deref_mut(), self.protocol_version).await;
+        #[cfg(feature = "signing")]
+        let result = read_versioned_msg_async_signed(
+            reader.deref_mut(),
+            self.protocol_version,
+            self.signing_data.as_ref(),
+        )
+        .await;
+        result
+    }
+
+    async fn send(
+        &self,
+        header: &MavHeader,
+        data: &M,
+    ) -> Result<usize, crate::error::MessageWriteError> {
+        let mut lock = self.writer.lock().await;
+
+        let header = MavHeader {
+            sequence: lock.sequence,
+            system_id: header.system_id,
+            component_id: header.component_id,
+        };
+
+        lock.sequence = lock.sequence.wrapping_add(1);
+        #[cfg(not(feature = "signing"))]
+        let result =
+            write_versioned_msg_async(&mut lock.socket, self.protocol_version, header, data).await;
+        #[cfg(feature = "signing")]
+        let result = write_versioned_msg_async_signed(
+            &mut lock.socket,
+            self.protocol_version,
+            header,
+            data,
+            self.signing_data.as_ref(),
+        )
+        .await;
+        result
+    }
+
+    fn set_protocol_version(&mut self, version: MavlinkVersion) {
+        self.protocol_version = version;
+    }
+
+    fn get_protocol_version(&self) -> MavlinkVersion {
+        self.protocol_version
+    }
+
+    #[cfg(feature = "signing")]
+    fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
+        self.signing_data = signing_data.map(SigningData::from_config)
+    }
+}

--- a/mavlink-core/src/async_connection/udp.rs
+++ b/mavlink-core/src/async_connection/udp.rs
@@ -1,3 +1,5 @@
+//! Async UDP MAVLink connection
+
 use core::{ops::DerefMut, task::Poll};
 use std::{collections::VecDeque, io::Read, sync::Arc};
 

--- a/mavlink-core/src/async_connection/udp.rs
+++ b/mavlink-core/src/async_connection/udp.rs
@@ -1,0 +1,277 @@
+use core::{ops::DerefMut, task::Poll};
+use std::{collections::VecDeque, io::Read, sync::Arc};
+
+use tokio::{
+    io::{self, AsyncRead, ReadBuf},
+    net::UdpSocket,
+    sync::Mutex,
+};
+
+use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Message};
+
+use super::{get_socket_addr, AsyncMavConnection};
+
+#[cfg(not(feature = "signing"))]
+use crate::{read_versioned_msg_async, write_versioned_msg_async};
+#[cfg(feature = "signing")]
+use crate::{
+    read_versioned_msg_async_signed, write_versioned_msg_signed, SigningConfig, SigningData,
+};
+
+pub async fn select_protocol<M: Message + Sync + Send>(
+    address: &str,
+) -> tokio::io::Result<Box<dyn AsyncMavConnection<M> + Sync + Send>> {
+    let connection = if let Some(address) = address.strip_prefix("udpin:") {
+        udpin(address).await
+    } else if let Some(address) = address.strip_prefix("udpout:") {
+        udpout(address).await
+    } else if let Some(address) = address.strip_prefix("udpbcast:") {
+        udpbcast(address).await
+    } else {
+        Err(tokio::io::Error::new(
+            tokio::io::ErrorKind::AddrNotAvailable,
+            "Protocol unsupported",
+        ))
+    };
+
+    Ok(Box::new(connection?))
+}
+
+pub async fn udpbcast<T: std::net::ToSocketAddrs>(address: T) -> tokio::io::Result<UdpConnection> {
+    let addr = get_socket_addr(address)?;
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    socket
+        .set_broadcast(true)
+        .expect("Couldn't bind to broadcast address.");
+    UdpConnection::new(socket, false, Some(addr))
+}
+
+pub async fn udpout<T: std::net::ToSocketAddrs>(address: T) -> tokio::io::Result<UdpConnection> {
+    let addr = get_socket_addr(address)?;
+    let socket = UdpSocket::bind("0.0.0.0:0").await?;
+    UdpConnection::new(socket, false, Some(addr))
+}
+
+pub async fn udpin<T: std::net::ToSocketAddrs>(address: T) -> tokio::io::Result<UdpConnection> {
+    let addr = address
+        .to_socket_addrs()
+        .unwrap()
+        .next()
+        .expect("Invalid address");
+    let socket = UdpSocket::bind(addr).await?;
+    UdpConnection::new(socket, true, None)
+}
+
+struct UdpRead {
+    socket: Arc<UdpSocket>,
+    buffer: VecDeque<u8>,
+    last_recv_address: Option<std::net::SocketAddr>,
+}
+
+const MTU_SIZE: usize = 1500;
+impl AsyncRead for UdpRead {
+    fn poll_read(
+        mut self: core::pin::Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.buffer.is_empty() {
+            let mut read_buffer = [0u8; MTU_SIZE];
+            let mut read_buffer = ReadBuf::new(&mut read_buffer);
+
+            match self.socket.poll_recv_from(cx, &mut read_buffer) {
+                Poll::Ready(Ok(address)) => {
+                    let n_buffer = read_buffer.filled().len();
+
+                    let n = (&read_buffer.filled()[0..n_buffer]).read(buf.initialize_unfilled())?;
+                    buf.advance(n);
+
+                    self.buffer.extend(&read_buffer.filled()[n..n_buffer]);
+                    self.last_recv_address = Some(address);
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                Poll::Pending => Poll::Pending,
+            }
+        } else {
+            let read_result = self.buffer.read(buf.initialize_unfilled());
+            let result = match read_result {
+                Ok(n) => {
+                    buf.advance(n);
+                    Ok(())
+                }
+                Err(err) => Err(err),
+            };
+            Poll::Ready(result)
+        }
+    }
+}
+
+struct UdpWrite {
+    socket: Arc<UdpSocket>,
+    dest: Option<std::net::SocketAddr>,
+    sequence: u8,
+}
+
+pub struct UdpConnection {
+    reader: Mutex<AsyncPeekReader<UdpRead>>,
+    writer: Mutex<UdpWrite>,
+    protocol_version: MavlinkVersion,
+    server: bool,
+    #[cfg(feature = "signing")]
+    signing_data: Option<SigningData>,
+}
+
+impl UdpConnection {
+    fn new(
+        socket: UdpSocket,
+        server: bool,
+        dest: Option<std::net::SocketAddr>,
+    ) -> tokio::io::Result<Self> {
+        let socket = Arc::new(socket);
+        Ok(Self {
+            server,
+            reader: Mutex::new(AsyncPeekReader::new(UdpRead {
+                socket: socket.clone(),
+                buffer: VecDeque::new(),
+                last_recv_address: None,
+            })),
+            writer: Mutex::new(UdpWrite {
+                socket,
+                dest,
+                sequence: 0,
+            }),
+            protocol_version: MavlinkVersion::V2,
+            #[cfg(feature = "signing")]
+            signing_data: None,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl<M: Message + Sync + Send> AsyncMavConnection<M> for UdpConnection {
+    async fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().await;
+
+        loop {
+            #[cfg(not(feature = "signing"))]
+            let result = read_versioned_msg_async(reader.deref_mut(), self.protocol_version).await;
+            #[cfg(feature = "signing")]
+            let result = read_versioned_msg_async_signed(
+                reader.deref_mut(),
+                self.protocol_version,
+                self.signing_data.as_ref(),
+            )
+            .await;
+            if self.server {
+                if let addr @ Some(_) = reader.reader_ref().last_recv_address {
+                    self.writer.lock().await.dest = addr;
+                }
+            }
+            if let ok @ Ok(..) = result {
+                return ok;
+            }
+        }
+    }
+
+    async fn send(
+        &self,
+        header: &MavHeader,
+        data: &M,
+    ) -> Result<usize, crate::error::MessageWriteError> {
+        let mut guard = self.writer.lock().await;
+        let state = &mut *guard;
+
+        let header = MavHeader {
+            sequence: state.sequence,
+            system_id: header.system_id,
+            component_id: header.component_id,
+        };
+
+        state.sequence = state.sequence.wrapping_add(1);
+
+        let len = if let Some(addr) = state.dest {
+            let mut buf = Vec::new();
+            #[cfg(not(feature = "signing"))]
+            write_versioned_msg_async(
+                &mut buf,
+                self.protocol_version,
+                header,
+                data,
+                #[cfg(feature = "signing")]
+                self.signing_data.as_ref(),
+            )
+            .await?;
+            #[cfg(feature = "signing")]
+            write_versioned_msg_signed(
+                &mut buf,
+                self.protocol_version,
+                header,
+                data,
+                #[cfg(feature = "signing")]
+                self.signing_data.as_ref(),
+            )?;
+            state.socket.send_to(&buf, addr).await?
+        } else {
+            0
+        };
+
+        Ok(len)
+    }
+
+    fn set_protocol_version(&mut self, version: MavlinkVersion) {
+        self.protocol_version = version;
+    }
+
+    fn get_protocol_version(&self) -> MavlinkVersion {
+        self.protocol_version
+    }
+
+    #[cfg(feature = "signing")]
+    fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
+        self.signing_data = signing_data.map(SigningData::from_config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn test_datagram_buffering() {
+        let receiver_socket = Arc::new(UdpSocket::bind("127.0.0.1:5001").await.unwrap());
+        let mut udp_reader = UdpRead {
+            socket: receiver_socket.clone(),
+            buffer: VecDeque::new(),
+            last_recv_address: None,
+        };
+        let sender_socket = UdpSocket::bind("0.0.0.0:0").await.unwrap();
+        sender_socket.connect("127.0.0.1:5001").await.unwrap();
+
+        let datagram: Vec<u8> = (0..50).collect::<Vec<_>>();
+
+        let mut n_sent = sender_socket.send(&datagram).await.unwrap();
+        assert_eq!(n_sent, datagram.len());
+        n_sent = sender_socket.send(&datagram).await.unwrap();
+        assert_eq!(n_sent, datagram.len());
+
+        let mut buf = [0u8; 30];
+
+        let mut n_read = udp_reader.read(&mut buf).await.unwrap();
+        assert_eq!(n_read, 30);
+        assert_eq!(&buf[0..n_read], (0..30).collect::<Vec<_>>().as_slice());
+
+        n_read = udp_reader.read(&mut buf).await.unwrap();
+        assert_eq!(n_read, 20);
+        assert_eq!(&buf[0..n_read], (30..50).collect::<Vec<_>>().as_slice());
+
+        n_read = udp_reader.read(&mut buf).await.unwrap();
+        assert_eq!(n_read, 30);
+        assert_eq!(&buf[0..n_read], (0..30).collect::<Vec<_>>().as_slice());
+
+        n_read = udp_reader.read(&mut buf).await.unwrap();
+        assert_eq!(n_read, 20);
+        assert_eq!(&buf[0..n_read], (30..50).collect::<Vec<_>>().as_slice());
+    }
+}

--- a/mavlink-core/src/async_peek_reader.rs
+++ b/mavlink-core/src/async_peek_reader.rs
@@ -1,0 +1,147 @@
+//! This module implements a buffered/peekable reader using async I/O.
+//!
+//! The purpose of the buffered/peekable reader is to allow for backtracking parsers.
+//!
+//! This is the async version of [`crate::peek_reader::PeekReader`].
+//! A reader implementing the tokio library's [`tokio::io::AsyncBufRead`]/[`tokio::io::AsyncBufReadExt`] traits seems like a good fit, but
+//! it does not allow for peeking a specific number of bytes, so it provides no way to request
+//! more data from the underlying reader without consuming the existing data.
+//!
+//! This API still tries to adhere to the [`tokio::io::AsyncBufRead`]'s trait philosophy.
+//!
+//! The main type [`AsyncPeekReader`] does not implement [`tokio::io::AsyncBufReadExt`] itself, as there is no added benefit
+//! in doing so.
+//!
+use tokio::io::AsyncReadExt;
+
+use crate::error::MessageReadError;
+
+/// A buffered/peekable reader
+///
+/// This reader wraps a type implementing [`tokio::io::AsyncRead`] and adds buffering via an internal buffer.
+///
+/// It allows the user to `peek` a specified number of bytes (without consuming them),
+/// to `read` bytes (consuming them), or to `consume` them after `peek`ing.
+///
+/// NOTE: This reader is generic over the size of the buffer, defaulting to MAVLink's current largest
+/// possible message size of 280 bytes
+///
+pub struct AsyncPeekReader<R, const BUFFER_SIZE: usize = 280> {
+    // Internal buffer
+    buffer: [u8; BUFFER_SIZE],
+    // The position of the next byte to read from the buffer.
+    cursor: usize,
+    // The position of the next byte to read into the buffer.
+    top: usize,
+    // The wrapped reader.
+    reader: R,
+}
+
+impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFER_SIZE> {
+    /// Instantiates a new [`AsyncPeekReader`], wrapping the provided [`tokio::io::AsyncReadExt`] and using the default chunk size
+    pub fn new(reader: R) -> Self {
+        Self {
+            buffer: [0; BUFFER_SIZE],
+            cursor: 0,
+            top: 0,
+            reader,
+        }
+    }
+
+    /// Peeks an exact amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function does not consume data from the buffer, so subsequent calls to `peek` or `read` functions
+    /// will still return the peeked data.
+    ///
+    pub async fn peek_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
+        self.fetch(amount, false).await
+    }
+
+    /// Reads a specified amount of bytes from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
+    ///
+    pub async fn read_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
+        self.fetch(amount, true).await
+    }
+
+    /// Reads a byte from the internal buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will read
+    /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
+    ///
+    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
+    ///
+    pub async fn read_u8(&mut self) -> Result<u8, MessageReadError> {
+        let buf = self.read_exact(1).await?;
+        Ok(buf[0])
+    }
+
+    /// Consumes a specified amount of bytes from the buffer
+    ///
+    /// If the internal buffer does not contain enough data, this function will consume as much data as is buffered.
+    ///
+    pub fn consume(&mut self, amount: usize) -> usize {
+        let amount = amount.min(self.top - self.cursor);
+        self.cursor += amount;
+        amount
+    }
+
+    /// Returns an immutable reference to the underlying [`tokio::io::AsyncRead`]
+    ///
+    /// Reading directly from the underlying stream will cause data loss
+    pub fn reader_ref(&mut self) -> &R {
+        &self.reader
+    }
+
+    /// Returns a mutable reference to the underlying [`tokio::io::AsyncRead`]
+    ///
+    /// Reading directly from the underlying stream will cause data loss
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
+    /// Internal function to fetch data from the internal buffer and/or reader
+    async fn fetch(&mut self, amount: usize, consume: bool) -> Result<&[u8], MessageReadError> {
+        let buffered = self.top - self.cursor;
+
+        // the caller requested more bytes than we have buffered, fetch them from the reader
+        if buffered < amount {
+            let bytes_read = amount - buffered;
+            assert!(bytes_read < BUFFER_SIZE);
+            let mut buf = [0u8; BUFFER_SIZE];
+
+            // read needed bytes from reader
+            self.reader.read_exact(&mut buf[..bytes_read]).await?;
+
+            // if some bytes were read, add them to the buffer
+
+            if self.buffer.len() - self.top < bytes_read {
+                // reallocate
+                self.buffer.copy_within(self.cursor..self.top, 0);
+                self.cursor = 0;
+                self.top = buffered;
+            }
+            self.buffer[self.top..self.top + bytes_read].copy_from_slice(&buf[..bytes_read]);
+            self.top += bytes_read;
+        }
+
+        let result = &self.buffer[self.cursor..self.cursor + amount];
+        if consume {
+            self.cursor += amount;
+        }
+        Ok(result)
+    }
+}

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -958,7 +958,6 @@ fn read_v2_raw_message_inner<M: Message, R: Read>(
 }
 
 /// Async read a raw buffer with the mavlink message
-///
 /// V2 maximum size is 280 bytes: `<https://mavlink.io/en/guide/serialization.html>`
 #[cfg(feature = "tokio-1")]
 pub async fn read_v2_raw_message_async<M: Message, R: tokio::io::AsyncReadExt + Unpin>(

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -1133,7 +1133,7 @@ async fn read_v2_msg_async_inner<M: Message, R: tokio::io::AsyncReadExt + Unpin>
     read: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<(MavHeader, M), error::MessageReadError> {
-    let message = read_v2_raw_message_async_signed::<M, _>(read, signing_data).await?;
+    let message = read_v2_raw_message_async_inner::<M, _>(read, signing_data).await?;
 
     Ok((
         MavHeader {
@@ -1212,7 +1212,7 @@ pub async fn write_versioned_msg_async<M: Message, W: tokio::io::AsyncWriteExt +
 }
 
 /// Async write a message with signing support using the given mavlink version
-#[cfg(feature = "tokio-1")]
+#[cfg(all(feature = "tokio-1", feature = "signing"))]
 pub async fn write_versioned_msg_async_signed<M: Message, W: tokio::io::AsyncWriteExt + Unpin>(
     w: &mut W,
     version: MavlinkVersion,

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -115,3 +115,6 @@ features = [
     "tokio-1",
     "signing"
 ]
+
+[dev-dependencies]
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "time" ] }

--- a/mavlink/tests/tcp_loopback_async_tests.rs
+++ b/mavlink/tests/tcp_loopback_async_tests.rs
@@ -1,0 +1,69 @@
+mod test_shared;
+
+#[cfg(all(feature = "tokio-1", feature = "tcp", feature = "common"))]
+mod test_tcp_connections {
+    #[cfg(feature = "signing")]
+    use crate::test_shared;
+    #[cfg(feature = "signing")]
+    use mavlink::SigningConfig;
+
+    /// Test whether we can send a message via TCP and receive it OK using async_connect.
+    /// This also test signing as a property of a MavConnection if the signing feature is enabled.
+    #[tokio::test]
+    pub async fn test_tcp_loopback() {
+        const RECEIVE_CHECK_COUNT: i32 = 5;
+
+        #[cfg(feature = "signing")]
+        let singing_cfg_server = SigningConfig::new(test_shared::SECRET_KEY, 0, true, false);
+        #[cfg(feature = "signing")]
+        let singing_cfg_client = singing_cfg_server.clone();
+
+        let server_thread = tokio::spawn(async move {
+            //TODO consider using get_available_port to use a random port
+            let mut server =
+                mavlink::connect_async("tcpin:0.0.0.0:14551").await.expect("Couldn't create server");
+
+            #[cfg(feature = "signing")]
+            server.setup_signing(Some(singing_cfg_server));
+
+            let mut recv_count = 0;
+            for _i in 0..RECEIVE_CHECK_COUNT {
+                match server.recv().await {
+                    Ok((_header, msg)) => {
+                        if let mavlink::common::MavMessage::HEARTBEAT(_heartbeat_msg) = msg {
+                            recv_count += 1;
+                        } else {
+                            // one message parse failure fails the test
+                            break;
+                        }
+                    }
+                    Err(..) => {
+                        // one message read failure fails the test
+                        break;
+                    }
+                }
+            }
+            assert_eq!(recv_count, RECEIVE_CHECK_COUNT);
+        });
+
+        // Give some time for the server to connect
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // have the client send a few hearbeats
+        tokio::spawn(async move {
+            let msg =
+                mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
+            let mut client =
+                mavlink::connect_async("tcpout:127.0.0.1:14551").await.expect("Couldn't create client");
+
+            #[cfg(feature = "signing")]
+            client.setup_signing(Some(singing_cfg_client));
+
+            for _i in 0..RECEIVE_CHECK_COUNT {
+                client.send_default(&msg).await.ok();
+            }
+        });
+
+        server_thread.await.unwrap();
+    }
+}

--- a/mavlink/tests/tcp_loopback_async_tests.rs
+++ b/mavlink/tests/tcp_loopback_async_tests.rs
@@ -20,8 +20,9 @@ mod test_tcp_connections {
 
         let server_thread = tokio::spawn(async move {
             //TODO consider using get_available_port to use a random port
-            let mut server =
-                mavlink::connect_async("tcpin:0.0.0.0:14551").await.expect("Couldn't create server");
+            let mut server = mavlink::connect_async("tcpin:0.0.0.0:14551")
+                .await
+                .expect("Couldn't create server");
 
             #[cfg(feature = "signing")]
             server.setup_signing(Some(singing_cfg_server));
@@ -53,8 +54,9 @@ mod test_tcp_connections {
         tokio::spawn(async move {
             let msg =
                 mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
-            let mut client =
-                mavlink::connect_async("tcpout:127.0.0.1:14551").await.expect("Couldn't create client");
+            let mut client = mavlink::connect_async("tcpout:127.0.0.1:14551")
+                .await
+                .expect("Couldn't create client");
 
             #[cfg(feature = "signing")]
             client.setup_signing(Some(singing_cfg_client));

--- a/mavlink/tests/udp_loopback_async_tests.rs
+++ b/mavlink/tests/udp_loopback_async_tests.rs
@@ -8,15 +8,18 @@ mod test_udp_connections {
     pub async fn test_udp_loopback() {
         const RECEIVE_CHECK_COUNT: i32 = 3;
 
-        let server = mavlink::connect_async("udpin:0.0.0.0:14552").await.expect("Couldn't create server");
+        let server = mavlink::connect_async("udpin:0.0.0.0:14552")
+            .await
+            .expect("Couldn't create server");
 
         // have the client send one heartbeat per second
         tokio::spawn({
             async move {
                 let msg =
                     mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
-                let client =
-                    mavlink::connect_async("udpout:127.0.0.1:14552").await.expect("Couldn't create client");
+                let client = mavlink::connect_async("udpout:127.0.0.1:14552")
+                    .await
+                    .expect("Couldn't create client");
                 loop {
                     client.send_default(&msg).await.ok();
                 }

--- a/mavlink/tests/udp_loopback_async_tests.rs
+++ b/mavlink/tests/udp_loopback_async_tests.rs
@@ -1,0 +1,46 @@
+mod test_shared;
+
+#[cfg(all(feature = "tokio-1", feature = "udp", feature = "common"))]
+mod test_udp_connections {
+
+    /// Test whether we can send a message via UDP and receive it OK using async_connect
+    #[tokio::test]
+    pub async fn test_udp_loopback() {
+        const RECEIVE_CHECK_COUNT: i32 = 3;
+
+        let server = mavlink::connect_async("udpin:0.0.0.0:14552").await.expect("Couldn't create server");
+
+        // have the client send one heartbeat per second
+        tokio::spawn({
+            async move {
+                let msg =
+                    mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
+                let client =
+                    mavlink::connect_async("udpout:127.0.0.1:14552").await.expect("Couldn't create client");
+                loop {
+                    client.send_default(&msg).await.ok();
+                }
+            }
+        });
+
+        //TODO use std::sync::WaitTimeoutResult to timeout ourselves if recv fails?
+        let mut recv_count = 0;
+        for _i in 0..RECEIVE_CHECK_COUNT {
+            match server.recv().await {
+                Ok((_header, msg)) => {
+                    if let mavlink::common::MavMessage::HEARTBEAT(_heartbeat_msg) = msg {
+                        recv_count += 1;
+                    } else {
+                        // one message parse failure fails the test
+                        break;
+                    }
+                }
+                Err(..) => {
+                    // one message read failure fails the test
+                    break;
+                }
+            }
+        }
+        assert_eq!(recv_count, RECEIVE_CHECK_COUNT);
+    }
+}


### PR DESCRIPTION
Implements #256.
Adds asynchronous connect method `async connect_async(address)` as async version of `connect(address)`.
For this the following is added when the `tokio-1` feature is enabled:
- `mod async_connection` with `connect_async(..)` 
- `trait AsyncMavConnection` as `[#[async_trait]` as an async verions of `trait MavConnection`
- `AsyncFileConnection`, `AsyncTcpConnection`, `AsyncUdpConnection` implementing `AsyncMavConnection`
- `AsyncPeekReader` as async verions of `PeekReader`
- read/write functions `read_versioned_msg_async`, `read_versioned_msg_async_signed`, `read_v1_raw_message_async`, `read_v1_msg_async`, `read_v2_msg_async_signed`, `write_versioned_msg_async_signed`, `write_v2_msg_async_signed`
- change functions `read_v2_raw_message_async`, `read_v2_raw_message_async_inner`, `read_v2_raw_message_async_signed`, `read_v2_msg_async` to read from a `AsyncPeekReader` instead of directly for a `tokio::io::AsyncReadExt`
- `connect_async` is exposed as `mavlink::connect_async`

Tests:
- Add async versions of tcp_loopback_tests.rs and udp_loopback_async_tests.rs
- `AsyncUdpConnection` tests datagram_buffering similar to its blocking sibling
- To run test the `tokio` features `rt`, `macros` are needed, for this reason `tokio` with these additional features is required as `dev-dependencies` for both `mavlink-core` and `mavlink`

Caveats 
- No serial support.
- The change of some existing function to `AsyncPeekReader` from `tokio::io::AsyncReadExt` is breaking
- The MSRV test fails (see #277/#278), test succeds locally for bins/lib targets or without using no-dev-deps.
- The combinations of asnyc and signing results in 4 versions of the same functions that effectifly do the same. (e.g. `write_versioned_msg`, `write_versioned_msg_signed`, `write_versioned_msg_async` and `write_versioned_msg_async_signed`)