### PR TITLE
Run MSRV check only for lib and bin targtets.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           toolchain: ${{ env.MSRV }}
       - uses: taiki-e/install-action@cargo-no-dev-deps
-      - run: cargo no-dev-deps check --all --all-targets ${{ matrix.features }}
+      - run: cargo no-dev-deps check --all --lib --bins ${{ matrix.features }}
 
   build:
     needs: [formatting, linting, internal-tests, mavlink-dump, msrv]


### PR DESCRIPTION
See #277.
Removes tests, examples and benches (there are currently no benches) from msrv test.
Since the msrv test runs without dev dependencies they would potentially not work.