### PR TITLE
mavlink-core: MAVLinkV1MessageRaw::header should not require mut

### DIFF
--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -325,7 +325,7 @@ impl MAVLinkV1MessageRaw {
     }
 
     #[inline]
-    pub fn header(&mut self) -> &[u8] {
+    pub fn header(&self) -> &[u8] {
         &self.0[1..=Self::HEADER_SIZE]
     }
 


### PR DESCRIPTION
This makes it coherent with MAVLinkV2MessageRaw::header