### PR TITLE
Fix: read error leads to message skip for blocking API

### DIFF
--- a/mavlink-core/src/embedded.rs
+++ b/mavlink-core/src/embedded.rs
@@ -5,6 +5,10 @@ const _: () = panic!("Only one of 'embedded' and 'embedded-hal-02' features can 
 
 /// Replacement for std::io::Read + byteorder::ReadBytesExt in no_std envs
 pub trait Read {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, MessageReadError> {
+        self.read_exact(buf).map(|_| buf.len())
+    }
+
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), MessageReadError>;
 }
 

--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -37,6 +37,15 @@ pub enum MessageReadError {
     Parse(ParserError),
 }
 
+impl MessageReadError {
+    pub fn eof() -> Self {
+        #[cfg(feature = "std")]
+        return Self::Io(std::io::ErrorKind::UnexpectedEof.into());
+        #[cfg(any(feature = "embedded", feature = "embedded-hal-02"))]
+        return Self::Io;
+    }
+}
+
 impl Display for MessageReadError {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -106,7 +106,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// Returns an immutable reference to the underlying [`std::io::Read`]er
     ///
     /// Reading directly from the underlying stream will cause data loss
-    pub fn reader_ref(&mut self) -> &R {
+    pub fn reader_ref(&self) -> &R {
         &self.reader
     }
 

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -134,6 +134,12 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
             // read needed bytes from reader
             let bytes_read = self.reader.read(&mut buf[..bytes_to_read])?;
 
+            if bytes_read == 0 {
+                return Err(MessageReadError::Io(
+                    std::io::ErrorKind::UnexpectedEof.into(),
+                ));
+            }
+
             // if some bytes were read, add them to the buffer
 
             if self.buffer.len() - self.top < bytes_read {

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -135,9 +135,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
             let bytes_read = self.reader.read(&mut buf[..bytes_to_read])?;
 
             if bytes_read == 0 {
-                return Err(MessageReadError::Io(
-                    std::io::ErrorKind::UnexpectedEof.into(),
-                ));
+                return Err(MessageReadError::eof());
             }
 
             // if some bytes were read, add them to the buffer

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -169,4 +169,24 @@ mod test_v2_encode_decode {
         assert_eq!(raw_msg.raw_bytes(), HEARTBEAT_V2);
         assert!(raw_msg.has_valid_crc::<mavlink::common::MavMessage>());
     }
+
+    #[test]
+    pub fn test_read_error() {
+        use std::io::ErrorKind;
+
+        use mavlink_core::error::MessageReadError;
+
+        let mut reader = PeekReader::new(crate::test_shared::BlockyReader::new(HEARTBEAT_V2));
+
+        loop {
+            match mavlink::read_v2_msg::<mavlink::common::MavMessage, _>(&mut reader) {
+                Ok((header, _)) => {
+                    assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
+                    break;
+                }
+                Err(MessageReadError::Io(err)) if err.kind() == ErrorKind::WouldBlock => {}
+                Err(err) => panic!("{err}"),
+            }
+        }
+    }
 }


### PR DESCRIPTION
ISSUE: Read error leads to message skip. It happens due consuming STX byte of message, even if message parsing isn't completed yet.

GOAL: I have custom readers that could return WouldBlock IO error at any time and code shall interrupt message parsing and return to this later.