### PR TITLE
Typed creation of MavConnection implementations

### DIFF
--- a/mavlink-core/src/connectable.rs
+++ b/mavlink-core/src/connectable.rs
@@ -1,0 +1,152 @@
+use core::fmt::Display;
+use std::io;
+
+#[derive(Debug, Clone, Copy)]
+pub enum UdpMode {
+    Udpin,
+    Udpout,
+    Udpcast,
+}
+
+#[derive(Debug, Clone)]
+pub struct UdpConnectable {
+    pub(crate) address: String,
+    pub(crate) mode: UdpMode,
+}
+
+impl UdpConnectable {
+    pub fn new(address: String, mode: UdpMode) -> Self {
+        Self { address, mode }
+    }
+}
+impl Display for UdpConnectable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mode = match self.mode {
+            UdpMode::Udpin => "udpin",
+            UdpMode::Udpout => "udpout",
+            UdpMode::Udpcast => "udpcast",
+        };
+        write!(f, "{mode}:{}", self.address)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SerialConnectable {
+    pub(crate) port_name: String,
+    pub(crate) baud_rate: usize,
+}
+
+impl SerialConnectable {
+    pub fn new(port_name: String, baud_rate: usize) -> Self {
+        Self {
+            port_name,
+            baud_rate,
+        }
+    }
+}
+impl Display for SerialConnectable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "serial:{}:{}", self.port_name, self.baud_rate)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TcpConnectable {
+    pub(crate) address: String,
+    pub(crate) is_out: bool,
+}
+
+impl TcpConnectable {
+    pub fn new(address: String, is_out: bool) -> Self {
+        Self { address, is_out }
+    }
+}
+impl Display for TcpConnectable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        if self.is_out {
+            write!(f, "tcpout:{}", self.address)
+        } else {
+            write!(f, "tcpin:{}", self.address)
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct FileConnectable {
+    pub(crate) address: String,
+}
+
+impl FileConnectable {
+    pub fn new(address: String) -> Self {
+        Self { address }
+    }
+}
+impl Display for FileConnectable {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "file:{}", self.address)
+    }
+}
+pub enum ConnectionAddress {
+    Tcp(TcpConnectable),
+    Udp(UdpConnectable),
+    Serial(SerialConnectable),
+    File(FileConnectable),
+}
+
+impl Display for ConnectionAddress {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Tcp(connectable) => write!(f, "{connectable}"),
+            Self::Udp(connectable) => write!(f, "{connectable}"),
+            Self::Serial(connectable) => write!(f, "{connectable}"),
+            Self::File(connectable) => write!(f, "{connectable}"),
+        }
+    }
+}
+
+impl ConnectionAddress {
+    pub fn parse_address(address: &str) -> Result<Self, io::Error> {
+        let (protocol, address) = address.split_once(':').ok_or(io::Error::new(
+            io::ErrorKind::AddrNotAvailable,
+            "Protocol unsupported",
+        ))?;
+        let conn = match protocol {
+            #[cfg(feature = "direct-serial")]
+            "serial" => {
+                let (port_name, baud) = address.split_once(':').ok_or(io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "Incomplete port settings",
+                ))?;
+                Self::Serial(SerialConnectable::new(
+                    port_name.to_string(),
+                    baud.parse().map_err(|_| {
+                        io::Error::new(io::ErrorKind::AddrNotAvailable, "Invalid baud rate")
+                    })?,
+                ))
+            }
+            #[cfg(feature = "tcp")]
+            "tcpin" | "tcpout" => Self::Tcp(TcpConnectable::new(
+                address.to_string(),
+                protocol == "tcpout",
+            )),
+            #[cfg(feature = "udp")]
+            "udpin" | "udpout" | "udpcast" => Self::Udp(UdpConnectable::new(
+                address.to_string(),
+                match protocol {
+                    "udpin" => UdpMode::Udpin,
+                    "udpout" => UdpMode::Udpout,
+                    "udpcast" => UdpMode::Udpcast,
+                    _ => unreachable!(),
+                },
+            )),
+            "file" => Self::File(FileConnectable::new(address.to_string())),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    "Protocol unsupported",
+                ))
+            }
+        };
+        Ok(conn)
+    }
+}

--- a/mavlink-core/src/connection/file.rs
+++ b/mavlink-core/src/connection/file.rs
@@ -1,5 +1,6 @@
 //! File MAVLINK connection
 
+use crate::connectable::FileConnectable;
 use crate::connection::MavConnection;
 use crate::error::{MessageReadError, MessageWriteError};
 use crate::peek_reader::PeekReader;
@@ -13,6 +14,8 @@ use std::sync::Mutex;
 use crate::read_versioned_msg;
 #[cfg(feature = "signing")]
 use crate::{read_versioned_msg_signed, SigningConfig, SigningData};
+
+use super::Connectable;
 
 pub fn open(file_path: &str) -> io::Result<FileConnection> {
     let file = File::open(file_path)?;
@@ -76,5 +79,11 @@ impl<M: Message> MavConnection<M> for FileConnection {
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
         self.signing_data = signing_data.map(SigningData::from_config)
+    }
+}
+
+impl Connectable for FileConnectable {
+    fn connect<M: Message>(&self) -> io::Result<Box<dyn MavConnection<M> + Sync + Send>> {
+        Ok(Box::new(open(&self.address)?))
     }
 }

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -48,12 +48,12 @@ pub mod bytes_mut;
 mod connection;
 pub mod error;
 #[cfg(feature = "std")]
-pub use self::connection::{connect, MavConnection};
+pub use self::connection::{connect, Connectable, MavConnection};
 
 #[cfg(feature = "tokio-1")]
 mod async_connection;
 #[cfg(feature = "tokio-1")]
-pub use self::async_connection::{connect_async, AsyncMavConnection};
+pub use self::async_connection::{connect_async, AsyncConnectable, AsyncMavConnection};
 
 #[cfg(feature = "tokio-1")]
 pub mod async_peek_reader;
@@ -73,6 +73,13 @@ mod signing;
 pub use self::signing::{SigningConfig, SigningData};
 #[cfg(feature = "signing")]
 use sha2::{Digest, Sha256};
+
+#[cfg(any(feature = "std", feature = "tokio-1"))]
+mod connectable;
+#[cfg(any(feature = "std", feature = "tokio-1"))]
+pub use connectable::{
+    ConnectionAddress, FileConnectable, SerialConnectable, TcpConnectable, UdpConnectable,
+};
 
 pub const MAX_FRAME_SIZE: usize = 280;
 

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -157,14 +157,6 @@ pub struct MavFrame<M: Message> {
 }
 
 impl<M: Message> MavFrame<M> {
-    /// Create a new frame with given message
-    //    pub fn new(msg: MavMessage) -> MavFrame {
-    //        MavFrame {
-    //            header: MavHeader::get_default_header(),
-    //            msg
-    //        }
-    //    }
-
     /// Serialize MavFrame into a vector, so it can be sent over a socket, for example.
     /// The resulting buffer will start with the sequence field of the Mavlink frame
     /// and will not include the initial packet marker, length field, and flags.
@@ -908,6 +900,7 @@ pub fn read_v2_raw_message_signed<M: Message, R: Read>(
     read_v2_raw_message_inner::<M, R>(reader, signing_data)
 }
 
+#[allow(unused_variables)]
 fn read_v2_raw_message_inner<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
@@ -969,6 +962,7 @@ pub async fn read_v2_raw_message_async<M: Message, R: tokio::io::AsyncReadExt + 
 /// Async read a raw buffer with the mavlink message
 /// V2 maximum size is 280 bytes: `<https://mavlink.io/en/guide/serialization.html>`
 #[cfg(feature = "tokio-1")]
+#[allow(unused_variables)]
 async fn read_v2_raw_message_async_inner<M: Message, R: tokio::io::AsyncReadExt + Unpin>(
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,

--- a/mavlink/tests/parse_test.rs
+++ b/mavlink/tests/parse_test.rs
@@ -1,0 +1,30 @@
+mod parse_tests {
+    use mavlink::ConnectionAddress;
+
+    fn assert_parse(addr: &str) {
+        assert_eq!(
+            format!("{}", ConnectionAddress::parse_address(addr).unwrap()),
+            addr
+        );
+    }
+
+    #[test]
+    fn test_parse() {
+        assert_parse("tcpin:example.com:99");
+        assert_parse("tcpout:127.0.0.1:14549");
+        assert_parse("file:/mnt/12_44-mav.bin");
+        assert_parse("file:C:\\mav_logs\\test.bin");
+        assert_parse("udpcast:[::1]:4567");
+        assert_parse("udpin:[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443");
+        assert_parse("udpout:1.1.1.1:1");
+        assert_parse("serial:/dev/ttyUSB0:9600");
+        assert_parse("serial:COM0:115200");
+
+        assert!(ConnectionAddress::parse_address("serial:/dev/ttyUSB0").is_err());
+        assert!(ConnectionAddress::parse_address("updout:1.1.1.1:1").is_err());
+        assert!(ConnectionAddress::parse_address("tcp:127.0.0.1:14540").is_err());
+        assert!(ConnectionAddress::parse_address("tcpin127.0.0.1:14540").is_err());
+        assert!(ConnectionAddress::parse_address(" udpout:1.1.1.1:1 ").is_err());
+        assert!(ConnectionAddress::parse_address(":udpcast:[::1]:4567").is_err());
+    }
+}


### PR DESCRIPTION
See #290 

Adds
- connection address data structs: `UdpConnectable`, `SerialConnectable`, `TcpConnectable` and `FileConnectable`
- `pub` enum `ConnectionAddress` representing a parsed address string with `::parse_address(&str) -> Self` constructor and `impl Display`
- `pub` traits `AsyncConnectable`, `Connectable` providing the `connect[_async]()` functions enabled with the `tokio-1` and `std` features 
- `parse_test` test to validate `ConnectionAddress`'s parse/fmt functions

Fixes:
- supress `unused_variables` warning when compiled without signing feature