### PR TITLE
Version agnostic message reading

### DIFF
--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -32,8 +32,17 @@ pub trait AsyncMavConnection<M: Message + Sync + Send> {
         data: &M,
     ) -> Result<usize, crate::error::MessageWriteError>;
 
+    /// Sets the MAVLink version to use for receiving (when `allow_recv_any_version()` is `false`) and sending messages.
     fn set_protocol_version(&mut self, version: MavlinkVersion);
-    fn get_protocol_version(&self) -> MavlinkVersion;
+    /// Gets the currently used MAVLink version
+    fn protocol_version(&self) -> MavlinkVersion;
+
+    /// Set wether MAVLink messages of either version may be received.
+    ///
+    /// If set to false only messages of the version configured with `set_protocol_version()` are received.
+    fn set_allow_recv_any_version(&mut self, allow: bool);
+    /// Wether messages of any MAVLink version may be received
+    fn allow_recv_any_version(&self) -> bool;
 
     /// Write whole frame
     async fn send_frame(
@@ -46,7 +55,7 @@ pub trait AsyncMavConnection<M: Message + Sync + Send> {
     /// Read whole frame
     async fn recv_frame(&self) -> Result<MavFrame<M>, crate::error::MessageReadError> {
         let (header, msg) = self.recv().await?;
-        let protocol_version = self.get_protocol_version();
+        let protocol_version = self.protocol_version();
         Ok(MavFrame {
             header,
             msg,

--- a/mavlink-core/src/connection/mod.rs
+++ b/mavlink-core/src/connection/mod.rs
@@ -19,16 +19,25 @@ mod file;
 
 /// A MAVLink connection
 pub trait MavConnection<M: Message> {
-    /// Receive a mavlink message.
+    /// Receive a MAVLink message.
     ///
     /// Blocks until a valid frame is received, ignoring invalid messages.
     fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
 
-    /// Send a mavlink message
+    /// Send a MAVLink message
     fn send(&self, header: &MavHeader, data: &M) -> Result<usize, crate::error::MessageWriteError>;
 
+    /// Sets the MAVLink version to use for receiving (when `allow_recv_any_version()` is `false`) and sending messages.
     fn set_protocol_version(&mut self, version: MavlinkVersion);
+    /// Gets the currently used MAVLink version
     fn protocol_version(&self) -> MavlinkVersion;
+
+    /// Set wether MAVLink messages of either version may be received.
+    ///
+    /// If set to false only messages of the version configured with `set_protocol_version()` are received.
+    fn set_allow_recv_any_version(&mut self, allow: bool);
+    /// Wether messages of any MAVLink version may be received
+    fn allow_recv_any_version(&self) -> bool;
 
     /// Write whole frame
     fn send_frame(&self, frame: &MavFrame<M>) -> Result<usize, crate::error::MessageWriteError> {

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -1328,7 +1328,7 @@ fn read_any_raw_message_inner<M: Message, R: Read>(
         // search for the magic framing value indicating start of MAVLink message
         let version = loop {
             let byte = reader.peek_exact(1)?[0];
-            if byte == MAV_STX_V2 {
+            if byte == MAV_STX {
                 break MavlinkVersion::V1;
             }
             if byte == MAV_STX_V2 {

--- a/mavlink-core/src/signing.rs
+++ b/mavlink-core/src/signing.rs
@@ -11,7 +11,7 @@ pub struct SigningConfig {
     secret_key: [u8; 32],
     link_id: u8,
     pub(crate) sign_outgoing: bool,
-    allow_unsigned: bool,
+    pub(crate) allow_unsigned: bool,
 }
 
 // mutable state of signing per connection

--- a/mavlink/tests/agnostic_decode_test.rs
+++ b/mavlink/tests/agnostic_decode_test.rs
@@ -1,0 +1,143 @@
+pub mod test_shared;
+
+use mavlink::MAV_STX;
+use mavlink::MAV_STX_V2;
+
+// 100 randomly generted bytes with 10 extra MAV_STX/MAV_STX_V2 each inserted
+const GARBAGE: [u8; 120] = [
+    0xfe, 0x43, 0x2d, MAV_STX, MAV_STX, 0x26, 0x1e, 0x33, 0x85, 0x38, 0x1d, 0x20, 0x20, 0x90, 0xd9,
+    0x24, 0xb6, 0xd7, 0xb1, 0x22, 0x3b, 0xaf, 0x7c, 0x2f, MAV_STX, 0x9d, 0x1a, 0x13, 0x16, 0x2b,
+    0xf8, 0x6f, 0xf4, 0xdc, 0x66, 0xff, 0x2d, MAV_STX_V2, 0xe2, 0x2c, 0xb1, MAV_STX_V2, 0x4e, 0xc9,
+    0xc6, 0xcb, 0x3e, 0x3e, 0xf4, MAV_STX_V2, MAV_STX_V2, 0x49, 0xbc, 0x11, 0xb7, 0xd4, 0x5e,
+    MAV_STX, 0x46, 0x6a, 0xd3, 0xb9, MAV_STX, 0xe3, 0x81, 0x1d, MAV_STX_V2, 0x80, 0x47, 0xfc, 0xff,
+    0x0c, 0xaa, 0xf3, MAV_STX, MAV_STX_V2, 0x87, 0x2f, 0x9a, 0x15, MAV_STX_V2, MAV_STX, 0x06, 0xc9,
+    0xe1, 0xc0, 0x98, 0xf5, 0x71, 0x78, 0x1c, 0x4a, 0xe3, 0xf1, MAV_STX_V2, 0x5f, 0xdb, 0x0e, 0x3f,
+    MAV_STX, 0x2e, MAV_STX_V2, 0x08, 0x39, 0x6e, 0x15, 0x3c, 0x55, 0xcb, 0x78, 0xe0, MAV_STX, 0x5a,
+    0xb3, 0x1b, 0xf9, MAV_STX, 0xe0, 0xa0, MAV_STX_V2,
+];
+
+#[cfg(all(feature = "std", feature = "common"))]
+mod test_agnostic_encode_decode {
+    use crate::GARBAGE;
+    use mavlink_core::peek_reader::PeekReader;
+    use std::io::Write;
+
+    #[test]
+    pub fn test_read_heartbeats() {
+        let mut buf = vec![];
+        _ = buf.write(crate::test_shared::HEARTBEAT_V1);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V2);
+        let mut r = PeekReader::new(buf.as_slice());
+        // read 2 messages
+        for _ in 0..2 {
+            let (header, msg) = mavlink::read_any_msg(&mut r).expect("Failed to parse message");
+
+            assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
+            let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
+
+            if let mavlink::common::MavMessage::HEARTBEAT(msg) = msg {
+                assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
+                assert_eq!(msg.mavtype, heartbeat_msg.mavtype);
+                assert_eq!(msg.autopilot, heartbeat_msg.autopilot);
+                assert_eq!(msg.base_mode, heartbeat_msg.base_mode);
+                assert_eq!(msg.system_status, heartbeat_msg.system_status);
+                assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
+            } else {
+                panic!("Decoded wrong message type")
+            }
+        }
+    }
+
+    #[test]
+    pub fn test_read_inbetween_garbage() {
+        // write some garbage bytes as well as 2 heartbeats and attempt to read them
+
+        let mut buf = vec![];
+        _ = buf.write(&GARBAGE);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V1);
+        _ = buf.write(&GARBAGE);
+        // only part of message
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V1[..5]);
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V2);
+        _ = buf.write(&GARBAGE);
+        // only part of message
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V1[5..]);
+        // add some zeros to prevent invalid package sizes from causing a read error
+        _ = buf.write(&[0; 100]);
+
+        let mut r = PeekReader::new(buf.as_slice());
+        _ = mavlink::read_any_msg::<mavlink::common::MavMessage, _>(&mut r).unwrap();
+        _ = mavlink::read_any_msg::<mavlink::common::MavMessage, _>(&mut r).unwrap();
+        assert!(
+            mavlink::read_any_msg::<mavlink::common::MavMessage, _>(&mut r).is_err(),
+            "Parsed message from garbage data"
+        )
+    }
+}
+
+#[cfg(all(feature = "std", feature = "tokio-1", feature = "common"))]
+mod test_agnostic_encode_decode_async {
+    use crate::GARBAGE;
+    use mavlink_core::async_peek_reader::AsyncPeekReader;
+    use std::io::Write;
+
+    #[tokio::test]
+    pub async fn test_read_heartbeats() {
+        let mut buf = vec![];
+        _ = buf.write(crate::test_shared::HEARTBEAT_V1);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V2);
+        let mut r = AsyncPeekReader::new(buf.as_slice());
+        // read 2 messages
+        for _ in 0..2 {
+            let (header, msg) = mavlink::read_any_msg_async(&mut r)
+                .await
+                .expect("Failed to parse message");
+
+            assert_eq!(header, crate::test_shared::COMMON_MSG_HEADER);
+            let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
+
+            if let mavlink::common::MavMessage::HEARTBEAT(msg) = msg {
+                assert_eq!(msg.custom_mode, heartbeat_msg.custom_mode);
+                assert_eq!(msg.mavtype, heartbeat_msg.mavtype);
+                assert_eq!(msg.autopilot, heartbeat_msg.autopilot);
+                assert_eq!(msg.base_mode, heartbeat_msg.base_mode);
+                assert_eq!(msg.system_status, heartbeat_msg.system_status);
+                assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
+            } else {
+                panic!("Decoded wrong message type")
+            }
+        }
+    }
+
+    #[tokio::test]
+    pub async fn test_read_inbetween_garbage() {
+        // write some garbage bytes as well as 2 heartbeats and attempt to read them
+
+        let mut buf = vec![];
+        _ = buf.write(&GARBAGE);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V1);
+        _ = buf.write(&GARBAGE);
+        // only part of message
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V1[..5]);
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V2);
+        _ = buf.write(&GARBAGE);
+        // only part of message
+        _ = buf.write(&crate::test_shared::HEARTBEAT_V1[5..]);
+        // add some zeros to prevent invalid package sizes from causing a read error
+        _ = buf.write(&[0; 100]);
+
+        let mut r = AsyncPeekReader::new(buf.as_slice());
+        _ = mavlink::read_any_msg_async::<mavlink::common::MavMessage, _>(&mut r)
+            .await
+            .unwrap();
+        _ = mavlink::read_any_msg_async::<mavlink::common::MavMessage, _>(&mut r)
+            .await
+            .unwrap();
+        assert!(
+            mavlink::read_any_msg_async::<mavlink::common::MavMessage, _>(&mut r)
+                .await
+                .is_err(),
+            "Parsed message from garbage data"
+        )
+    }
+}

--- a/mavlink/tests/test_shared/mod.rs
+++ b/mavlink/tests/test_shared/mod.rs
@@ -12,6 +12,50 @@ pub const SECRET_KEY: [u8; 32] = [
     0x22, 0x42, 0x00, 0xcc, 0xff, 0x7a, 0x00, 0x52, 0x75, 0x73, 0x74, 0x00, 0x4d, 0x41, 0x56, 0xb3,
 ];
 
+pub const HEARTBEAT_V1: &[u8] = &[
+    mavlink::MAV_STX,
+    0x09,
+    crate::test_shared::COMMON_MSG_HEADER.sequence,
+    crate::test_shared::COMMON_MSG_HEADER.system_id,
+    crate::test_shared::COMMON_MSG_HEADER.component_id,
+    0x00, //msg ID
+    0x05, //payload
+    0x00,
+    0x00,
+    0x00,
+    0x02,
+    0x03,
+    0x59,
+    0x03,
+    0x03,
+    0x1f, //checksum
+    0x50,
+];
+
+pub const HEARTBEAT_V2: &[u8] = &[
+    mavlink::MAV_STX_V2, //magic
+    0x09,                //payload len
+    0,                   //incompat flags
+    0,                   //compat flags
+    crate::test_shared::COMMON_MSG_HEADER.sequence,
+    crate::test_shared::COMMON_MSG_HEADER.system_id,
+    crate::test_shared::COMMON_MSG_HEADER.component_id,
+    0x00, //msg ID
+    0x00,
+    0x00,
+    0x05, //payload
+    0x00,
+    0x00,
+    0x00,
+    0x02,
+    0x03,
+    0x59,
+    0x03,
+    0x03,
+    46, //checksum
+    115,
+];
+
 #[cfg(feature = "common")]
 pub fn get_heartbeat_msg() -> mavlink::common::HEARTBEAT_DATA {
     mavlink::common::HEARTBEAT_DATA {

--- a/mavlink/tests/v1_encode_decode_tests.rs
+++ b/mavlink/tests/v1_encode_decode_tests.rs
@@ -2,27 +2,8 @@ pub mod test_shared;
 
 #[cfg(all(feature = "std", feature = "common"))]
 mod test_v1_encode_decode {
+    use crate::test_shared::HEARTBEAT_V1;
     use mavlink_core::peek_reader::PeekReader;
-
-    pub const HEARTBEAT_V1: &[u8] = &[
-        mavlink::MAV_STX,
-        0x09,
-        crate::test_shared::COMMON_MSG_HEADER.sequence,
-        crate::test_shared::COMMON_MSG_HEADER.system_id,
-        crate::test_shared::COMMON_MSG_HEADER.component_id,
-        0x00,
-        0x05,
-        0x00,
-        0x00,
-        0x00,
-        0x02,
-        0x03,
-        0x59,
-        0x03,
-        0x03,
-        0x1f,
-        0x50,
-    ];
 
     #[test]
     pub fn test_read_heartbeat() {

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -2,31 +2,8 @@ mod test_shared;
 
 #[cfg(all(feature = "std", feature = "common"))]
 mod test_v2_encode_decode {
+    use crate::test_shared::HEARTBEAT_V2;
     use mavlink_core::peek_reader::PeekReader;
-
-    pub const HEARTBEAT_V2: &[u8] = &[
-        mavlink::MAV_STX_V2, //magic
-        0x09,                //payload len
-        0,                   //incompat flags
-        0,                   //compat flags
-        crate::test_shared::COMMON_MSG_HEADER.sequence,
-        crate::test_shared::COMMON_MSG_HEADER.system_id,
-        crate::test_shared::COMMON_MSG_HEADER.component_id,
-        0x00,
-        0x00,
-        0x00, //msg ID
-        0x05,
-        0x00,
-        0x00,
-        0x00,
-        0x02,
-        0x03,
-        0x59,
-        0x03,
-        0x03, //payload
-        46,
-        115, //checksum
-    ];
 
     #[test]
     pub fn test_read_v2_heartbeat() {


### PR DESCRIPTION
This PR add the option to receive messages MAVLink version agnostic.
Connections can be configured for what kind of message they may receive (either single version or both) and new `read_any..()` functions have been added in parallel to `read_v1..()` and `read_v2..()`.

Breaking changes: 
- `read_versioned_msg()`,`read_versioned_msg_async()`,`read_versioned_msg_signed()`,`read_versioned_msg_async_signed()` now take `ReadVersion` instead of `MavlinkVersion`, arrising errors can be fixed by calling `.into()` on the `MavlinkVersion` argument
- renamed `get_protocol_version()` in `AsyncMavConnection` trait to `protocol_version()` to be in line with naming in `MavConnection` trait 

Additions: 
- `enum ReadVersion` (`impl From<MavlinkVersion>`)
- `enum MAVLinkMessageRaw` for `MAVLinkV1MessageRaw`/`MAVLinkV2MessageRaw` with `payload()`, `sequence()`, `system_id()`, `component_id()`, `version()`  functions
- 4 functions `read_any_msg[_async][_signed]()`, analog to v1/v2 versions of the same function
- 4 functions `read_any_raw_message[_async][_signed]()` analog to v1/v2 versions of the same function
- add setter `set_allow_recv_any_version()` and getter `allow_recv_any_version()` to `[Async]MavConnection` and  to configure connections to allow receiving any version (sending will still only be done in the version configured using `set_protocol_version()`)

Docs:
- add doc for additions
- add missing doc for `MAVLinkV1MessageRaw`, `MAVLinkV2MessageRaw`
- add missing doc for `[Async]MavConnection::set_protocol_version()`, `::protocol_version()`

Tests (both blocking and async):
- read Heartbeats of 2 versions from same source
- read from data stream containing garbage data