### PR TITLE
Fix release CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,9 @@ jobs:
         cargo workspaces version custom ${{ steps.get_version.outputs.version }} \
           --exact --yes --no-git-tag --no-git-push \
           -m "Commit new release ${{ steps.get_version.outputs.version }}"
-        cargo workspaces publish --yes --no-verify --publish-as-is
+        cargo publish -p mavlink-core --no-verify
+        cargo publish -p mavlink-bindgen --no-verify
+        cargo publish -p mavlink --no-verify
     - name: Push commit
       run: |
         git push origin ${{ github.event.repository.default_branch }}

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -19,7 +19,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [build-dependencies]
-mavlink-bindgen = { path = "../mavlink-bindgen", default-features = false }
+mavlink-bindgen = { version = "0.13.2", path = "../mavlink-bindgen", default-features = false }
 
 [[example]]
 name = "mavlink-dump"
@@ -27,7 +27,7 @@ path = "examples/mavlink-dump/src/main.rs"
 required-features = ["ardupilotmega"]
 
 [dependencies]
-mavlink-core = { path = "../mavlink-core", default-features = false }
+mavlink-core = { version="0.14.0", path = "../mavlink-core", default-features = false }
 num-traits = { workspace = true, default-features = false }
 num-derive = { workspace = true }
 bitflags = { workspace = true }


### PR DESCRIPTION
Attempts to fix #274.
- add version dependencies to for `mavlink-core` and `mavlink-bindgen to `mavlink`
- replace workspace publish with 3 single crate publishes, this is done since I could not get it to work with `--dry-run`, it is possible it works after all.
- The current version numbers on the different crates are kind of a mess but should be fixed by the commit created by the deploy pipeline depending on the latest tag (currently 0.13.2)
