### PR TITLE
Suppress suspicious_else_formatting lint in generated code

### DIFF
--- a/mavlink-bindgen/src/binder.rs
+++ b/mavlink-bindgen/src/binder.rs
@@ -12,6 +12,7 @@ pub fn generate<W: Write>(modules: Vec<&str>, out: &mut W) {
             #[allow(non_snake_case)]
             #[allow(clippy::unnecessary_cast)]
             #[allow(clippy::bad_bit_mask)]
+            #[allow(clippy::suspicious_else_formatting)]
             #[cfg(feature = #module)]
             pub mod #module_ident;
         }


### PR DESCRIPTION
Suppress clippy warning about `if` statements  that looks like it should be else if in the generated code (`suspicious_else_formatting`) like bellow:
```
warning: this looks like an `else if` but the `else` is missing
 --> /home/user/Documents/folder/rust-mavlink/target/debug/build/mavlink-701ae44e620db1b6/out/all.rs:1:261081
  |
1 | ...mall (need {} bytes, but got {})" , Self :: ENCODED_LEN , __tmp . remaining () ,) } if matches ! (version , MavlinkVersion :: V2) { let len = __tmp . len () ; :: mavli...
  |                                                                                       ^
  |
  = note: to remove this lint, add the missing `else` or add a new line before the second `if`
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#suspicious_else_formatting
  ```
Note that the warning only appears when used without the `format-generated-code` feature.