### PR TITLE
Improve build error handling

### DIFF
--- a/mavlink/build/main.rs
+++ b/mavlink/build/main.rs
@@ -8,6 +8,12 @@ use std::process::{Command, ExitCode};
 fn main() -> ExitCode {
     let src_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
 
+    // Check if git is installed
+    if Command::new("git").arg("--version").status().is_err() {
+        eprintln!("error: Git is not installed or could not be found.");
+        return ExitCode::FAILURE;
+    }
+
     // Update and init submodule
     if let Err(error) = Command::new("git")
         .arg("submodule")
@@ -16,7 +22,7 @@ fn main() -> ExitCode {
         .current_dir(src_dir)
         .status()
     {
-        eprintln!("{error}");
+        eprintln!("Failed to update MAVLink definitions submodule: {error}");
         return ExitCode::FAILURE;
     }
 
@@ -32,7 +38,7 @@ fn main() -> ExitCode {
                 .current_dir(&mavlink_dir)
                 .status()
             {
-                eprintln!("{error}");
+                eprintln!("Failed to apply MAVLink definitions patches: {error}");
                 return ExitCode::FAILURE;
             }
         }


### PR DESCRIPTION
When invastigating #306 I noticed some defiencies in the build error handling:
- in the unlikely case that the building system does not have git installed the build fails with the rather unhelpfull "No such file or directory" message.
- the point of failure is not specified when one of the git commands fails.

Therefore I
- Added a check if git is installed by running `git --version`
- Improved the error messages in case the further git operations fail.