### PR TITLE
fix: tcp, udp, and serial features were not fully configured for conditional compilation

### DIFF
--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -97,6 +97,7 @@ pub async fn connect_async<M: Message + Sync + Send>(
 }
 
 /// Returns the socket address for the given address.
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) fn get_socket_addr<T: std::net::ToSocketAddrs>(
     address: T,
 ) -> Result<std::net::SocketAddr, io::Error> {
@@ -126,8 +127,11 @@ impl AsyncConnectable for ConnectionAddress {
         M: Message + Sync + Send,
     {
         match self {
+            #[cfg(feature = "tcp")]
             Self::Tcp(connectable) => connectable.connect_async::<M>().await,
+            #[cfg(feature = "udp")]
             Self::Udp(connectable) => connectable.connect_async::<M>().await,
+            #[cfg(feature = "direct-serial")]
             Self::Serial(connectable) => connectable.connect_async::<M>().await,
             Self::File(connectable) => connectable.connect_async::<M>().await,
         }

--- a/mavlink-core/src/connectable.rs
+++ b/mavlink-core/src/connectable.rs
@@ -87,8 +87,11 @@ impl Display for FileConnectable {
     }
 }
 pub enum ConnectionAddress {
+    #[cfg(feature = "tcp")]
     Tcp(TcpConnectable),
+    #[cfg(feature = "udp")]
     Udp(UdpConnectable),
+    #[cfg(feature = "direct-serial")]
     Serial(SerialConnectable),
     File(FileConnectable),
 }
@@ -96,8 +99,11 @@ pub enum ConnectionAddress {
 impl Display for ConnectionAddress {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
+            #[cfg(feature = "tcp")]
             Self::Tcp(connectable) => write!(f, "{connectable}"),
+            #[cfg(feature = "udp")]
             Self::Udp(connectable) => write!(f, "{connectable}"),
+            #[cfg(feature = "direct-serial")]
             Self::Serial(connectable) => write!(f, "{connectable}"),
             Self::File(connectable) => write!(f, "{connectable}"),
         }

--- a/mavlink-core/src/connection/mod.rs
+++ b/mavlink-core/src/connection/mod.rs
@@ -87,6 +87,7 @@ pub fn connect<M: Message + Sync + Send>(
 }
 
 /// Returns the socket address for the given address.
+#[cfg(any(feature = "tcp", feature = "udp"))]
 pub(crate) fn get_socket_addr<T: std::net::ToSocketAddrs>(
     address: &T,
 ) -> Result<std::net::SocketAddr, io::Error> {
@@ -106,8 +107,11 @@ impl Connectable for ConnectionAddress {
         M: Message,
     {
         match self {
+            #[cfg(feature = "tcp")]
             Self::Tcp(connectable) => connectable.connect::<M>(),
+            #[cfg(feature = "udp")]
             Self::Udp(connectable) => connectable.connect::<M>(),
+            #[cfg(feature = "direct-serial")]
             Self::Serial(connectable) => connectable.connect::<M>(),
             Self::File(connectable) => connectable.connect::<M>(),
         }


### PR DESCRIPTION
With the 0.14.0 tag, compiling rust-mavlink with just the feature `std` produces compilation errors due to the `tcp`,`udp`, and `direct-serial` features conditionally implementing the `Connectable` trait. This PR adds missing conditional compilation flags on all code paths regarding the TCP, UDP, and serial functionality. 

I would suggest adding the following feature combinations to CI in order to catch a problem like this in the future.
- `cargo build --no-default-features -F std,tokio-1`
- `cargo build --no-default-features -F std,tokio-1,tcp`
- `cargo build --no-default-features -F std,tokio-1,udp`
- `cargo build --no-default-features -F std,tokio-1,direct-serial`

If you wish, I can open another pull request with these modifications to the github actions workflow.

Initial compiler error:
![image](https://github.com/user-attachments/assets/9fed10ba-2517-41f8-81a4-96599c5c1167)
