### PR TITLE
Remove dialect feature depencies

### DIFF
--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -37,45 +37,28 @@ arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
 
 [features]
-default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega"]
-all = [
-    "ardupilotmega",
-    "asluav",
-    "common",
-    "development",
-    "icarous",
-    "minimal",
-    "python_array_test",
-    "standard",
-    "test",
-    "ualberta",
-    "uavionix",
-    "avssuas",
-    "cubepilot",
-    "storm32",
-    "csairlink",
-    "loweheiser"
-]
+default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega", "common"]
 
-ardupilotmega = ["common", "icarous", "uavionix"]
-asluav = ["common"]
-avssuas = ["common"]
-development = ["common"]
-matrixpilot = ["common"]
+all = []
+ardupilotmega = []
+asluav = []
+avssuas = []
+development = []
+matrixpilot = []
 minimal = []
-paparazzi = ["common"]
-python_array_test = ["common"]
-slugs = ["common"]
-standard = ["common"]
+paparazzi = []
+python_array_test = []
+slugs = []
+standard = []
 test = []
-ualberta = ["common"]
-uavionix = ["common"]
+ualberta = []
+uavionix = []
 icarous = []
 common = []
-cubepilot = ["common"]
+cubepilot = []
 csairlink = []
-loweheiser = ["minimal"]
-storm32 = ["ardupilotmega"]
+loweheiser = []
+storm32 = []
 
 all-dialects = [
     "ardupilotmega",

--- a/mavlink/tests/agnostic_decode_test.rs
+++ b/mavlink/tests/agnostic_decode_test.rs
@@ -58,7 +58,7 @@ mod test_agnostic_encode_decode {
         _ = buf.write(&GARBAGE);
         // only part of message
         _ = buf.write(&crate::test_shared::HEARTBEAT_V1[..5]);
-        _ = buf.write(&crate::test_shared::HEARTBEAT_V2);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V2);
         _ = buf.write(&GARBAGE);
         // only part of message
         _ = buf.write(&crate::test_shared::HEARTBEAT_V1[5..]);
@@ -119,7 +119,7 @@ mod test_agnostic_encode_decode_async {
         _ = buf.write(&GARBAGE);
         // only part of message
         _ = buf.write(&crate::test_shared::HEARTBEAT_V1[..5]);
-        _ = buf.write(&crate::test_shared::HEARTBEAT_V2);
+        _ = buf.write(crate::test_shared::HEARTBEAT_V2);
         _ = buf.write(&GARBAGE);
         // only part of message
         _ = buf.write(&crate::test_shared::HEARTBEAT_V1[5..]);

--- a/mavlink/tests/encode_decode_tests.rs
+++ b/mavlink/tests/encode_decode_tests.rs
@@ -72,7 +72,7 @@ mod test_encode_decode {
     /// This test makes sure that we can still receive messages in the common set
     /// properly when we're trying to decode APM messages.
     #[test]
-    #[cfg(all(feature = "ardupilotmega", feature = "uavionix", feature = "icarous"))]
+    #[cfg(feature = "ardupilotmega")]
     pub fn test_echo_apm_heartbeat() {
         use mavlink::ardupilotmega;
 
@@ -101,7 +101,7 @@ mod test_encode_decode {
     /// in the common set also get encoded and decoded
     /// properly.
     #[test]
-    #[cfg(all(feature = "ardupilotmega", feature = "uavionix", feature = "icarous"))]
+    #[cfg(feature = "ardupilotmega")]
     pub fn test_echo_apm_mount_status() {
         use mavlink::ardupilotmega;
 
@@ -125,7 +125,7 @@ mod test_encode_decode {
     }
 
     #[test]
-    #[cfg(all(feature = "ardupilotmega", feature = "uavionix", feature = "icarous"))]
+    #[cfg(feature = "ardupilotmega")]
     pub fn test_echo_apm_command_int() {
         use mavlink::ardupilotmega;
 

--- a/mavlink/tests/mav_frame_tests.rs
+++ b/mavlink/tests/mav_frame_tests.rs
@@ -1,9 +1,7 @@
 pub mod test_shared;
 
 mod mav_frame_tests {
-    use mavlink::ardupilotmega::MavMessage;
     use mavlink::MavFrame;
-    use mavlink::MavHeader;
 
     // NOTE: No STX, length, or flag fields in the header
     pub const HEARTBEAT_V2: &[u8] = &[
@@ -31,9 +29,10 @@ mod mav_frame_tests {
         0xf0,
     ];
 
+    #[cfg(feature = "common")]
     #[test]
     pub fn test_deser_ser() {
-        use mavlink::{common::MavMessage, MavFrame, MavlinkVersion};
+        use mavlink::{common::MavMessage, MavlinkVersion};
         let frame = MavFrame::<MavMessage>::deser(MavlinkVersion::V2, HEARTBEAT_V2)
             .expect("failed to parse message");
 
@@ -56,6 +55,7 @@ mod mav_frame_tests {
         assert_eq!(msg.mavlink_version, heartbeat_msg.mavlink_version);
     }
 
+    #[cfg(feature = "ardupilotmega")]
     #[test]
     pub fn test_deser_ser_message() {
         let buf: &mut [u8; 255] = &mut [0; 255];
@@ -75,6 +75,7 @@ mod mav_frame_tests {
         );
     }
 
+    #[cfg(feature = "ardupilotmega")]
     fn mavlink_message() -> mavlink::ardupilotmega::MavMessage {
         mavlink::ardupilotmega::MavMessage::LINK_NODE_STATUS(
             mavlink::ardupilotmega::LINK_NODE_STATUS_DATA {
@@ -93,7 +94,9 @@ mod mav_frame_tests {
         )
     }
 
-    fn new(msg: MavMessage) -> MavFrame<MavMessage> {
+    #[cfg(feature = "ardupilotmega")]
+    fn new(msg: mavlink::ardupilotmega::MavMessage) -> MavFrame<mavlink::ardupilotmega::MavMessage> {
+        use mavlink::MavHeader;
         MavFrame {
             header: MavHeader {
                 system_id: 1,

--- a/mavlink/tests/parse_test.rs
+++ b/mavlink/tests/parse_test.rs
@@ -1,3 +1,4 @@
+#[cfg(any(feature = "std", feature = "tokio-1"))]
 mod parse_tests {
     use mavlink::ConnectionAddress;
 
@@ -8,18 +9,37 @@ mod parse_tests {
         );
     }
 
+    #[cfg(feature = "tcp")]
     #[test]
-    fn test_parse() {
+    fn test_parse_tcp() {
         assert_parse("tcpin:example.com:99");
         assert_parse("tcpout:127.0.0.1:14549");
+    }
+
+    #[cfg(feature = "tcp")]
+    #[test]
+    fn test_parse_file() {
         assert_parse("file:/mnt/12_44-mav.bin");
         assert_parse("file:C:\\mav_logs\\test.bin");
+    }
+
+    #[cfg(feature = "udp")]
+    #[test]
+    fn test_parse_udp() {
         assert_parse("udpcast:[::1]:4567");
         assert_parse("udpin:[2001:db8:85a3:8d3:1319:8a2e:370:7348]:443");
         assert_parse("udpout:1.1.1.1:1");
+    }
+
+    #[cfg(feature = "direct-serial")]
+    #[test]
+    fn test_parse_serial() {
         assert_parse("serial:/dev/ttyUSB0:9600");
         assert_parse("serial:COM0:115200");
+    }
 
+    #[test]
+    fn test_parse_errors() {
         assert!(ConnectionAddress::parse_address("serial:/dev/ttyUSB0").is_err());
         assert!(ConnectionAddress::parse_address("updout:1.1.1.1:1").is_err());
         assert!(ConnectionAddress::parse_address("tcp:127.0.0.1:14540").is_err());

--- a/mavlink/tests/tcp_loopback_async_tests.rs
+++ b/mavlink/tests/tcp_loopback_async_tests.rs
@@ -20,6 +20,7 @@ mod test_tcp_connections {
 
         let server_thread = tokio::spawn(async move {
             //TODO consider using get_available_port to use a random port
+            #[allow(unused_mut)]
             let mut server = mavlink::connect_async("tcpin:0.0.0.0:14551")
                 .await
                 .expect("Couldn't create server");
@@ -54,6 +55,7 @@ mod test_tcp_connections {
         tokio::spawn(async move {
             let msg =
                 mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
+            #[allow(unused_mut)]
             let mut client = mavlink::connect_async("tcpout:127.0.0.1:14551")
                 .await
                 .expect("Couldn't create client");

--- a/mavlink/tests/tcp_loopback_tests.rs
+++ b/mavlink/tests/tcp_loopback_tests.rs
@@ -21,6 +21,7 @@ mod test_tcp_connections {
 
         let server_thread = thread::spawn(move || {
             //TODO consider using get_available_port to use a random port
+            #[allow(unused_mut)]
             let mut server =
                 mavlink::connect("tcpin:0.0.0.0:14550").expect("Couldn't create server");
 
@@ -54,6 +55,7 @@ mod test_tcp_connections {
         thread::spawn(move || {
             let msg =
                 mavlink::common::MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg());
+            #[allow(unused_mut)]
             let mut client =
                 mavlink::connect("tcpout:127.0.0.1:14550").expect("Couldn't create client");
 

--- a/mavlink/tests/test_shared/mod.rs
+++ b/mavlink/tests/test_shared/mod.rs
@@ -144,7 +144,7 @@ pub fn get_servo_output_raw_v2() -> mavlink::common::SERVO_OUTPUT_RAW_DATA {
     }
 }
 
-#[cfg(all(feature = "ardupilotmega", feature = "uavionix", feature = "icarous"))]
+#[cfg(feature = "ardupilotmega")]
 pub fn get_apm_mount_status() -> mavlink::ardupilotmega::MOUNT_STATUS_DATA {
     mavlink::ardupilotmega::MOUNT_STATUS_DATA {
         pointing_a: 3,


### PR DESCRIPTION
## Conents
Since #113 the generated code of different mavlink dialects that include each others XML files, are no longer dependent on each other.
But the features are still depndent in the `Cargo.toml`. This causes the generation of a lot of dialect code that is not required, for example using `ardupilotmega` would generate the content of `common` 3 time in `common`, `ardupilotmega` and `uavionix`. This PR removes these depencies.
This in itself is a **breaking** change.

## Default Features
Furthermore the dialects enabled by default where `ardupilotmega` its 3 dependencies `common`, `icarous`, `uavionix`.
I added `common` back to the default list but `icarous` and  `uavionix` are not directly available by default with this change.
I think when they are required they should be manually included, but this can be changed if required.
This is also a a **breaking** change.

## Test 
When validating these changes I fixed some minor issues with tests under certain feature combinations:
- supress unused_mut warning
- remove feature gates that are not required
- fix a needless_borrow lint
- adjust tests for #310
- fix feature gates in mav_frame_tests