### PR TITLE
fix: remove outdated slugs dialect

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          dialect: ["ardupilotmega", "asluav", "matrixpilot", "minimal", "paparazzi", "python_array_test", "slugs", "standard", "test", "ualberta", "uavionix", "icarous", "common", "storm32", "csairlink", "loweheiser"]
+          dialect: ["ardupilotmega", "asluav", "matrixpilot", "minimal", "paparazzi", "python_array_test", "standard", "test", "ualberta", "uavionix", "icarous", "common", "storm32", "csairlink", "loweheiser"]
           signing: ["", "--features signing"]
     steps:
       - uses: actions/checkout@master

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -48,7 +48,6 @@ matrixpilot = []
 minimal = []
 paparazzi = []
 python_array_test = []
-slugs = []
 standard = []
 test = []
 ualberta = []
@@ -69,7 +68,6 @@ all-dialects = [
     "minimal",
     "paparazzi",
     "python_array_test",
-    "slugs",
     "standard",
     "test",
     "ualberta",


### PR DESCRIPTION
slugs.xml was removed in 2020 https://github.com/mavlink/mavlink/pull/1473 from the message definitions but the feature stuck around (without doing anything).

This is technically a breaking change since a feature is remove but this does not change any functionality since no code was generated since there was no slugs.xml to be found.  