### PR TITLE
implement `try_recv` to `MavConnection`

### DIFF
--- a/mavlink-core/src/connection/mod.rs
+++ b/mavlink-core/src/connection/mod.rs
@@ -24,6 +24,12 @@ pub trait MavConnection<M: Message> {
     /// Blocks until a valid frame is received, ignoring invalid messages.
     fn recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
 
+    /// Try to receive a MAVLink message.
+    ///
+    /// Non-blocking variant of `recv()`, returns immediately with a `MessageReadError`
+    /// if there is an error or no message is available.
+    fn try_recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError>;
+
     /// Send a MAVLink message
     fn send(&self, header: &MavHeader, data: &M) -> Result<usize, crate::error::MessageWriteError>;
 

--- a/mavlink-core/src/connection/tcp.rs
+++ b/mavlink-core/src/connection/tcp.rs
@@ -96,6 +96,10 @@ impl<M: Message> MavConnection<M> for TcpConnection {
         result
     }
 
+    fn try_recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {
+        self.recv()
+    }
+
     fn send(&self, header: &MavHeader, data: &M) -> Result<usize, crate::error::MessageWriteError> {
         let mut lock = self.writer.lock().unwrap();
 


### PR DESCRIPTION
Right now, in order to release the `recv` lock in my current project, I have to do this:

```rs
async fn message_loop(self: Arc<Self>) {
    loop {
        let recv_future = smol::unblock({
            let _self = self.clone();
            move || _self.connection.recv()
        });

        match recv_future.timeout(Duration::from_millis(200)).await {
            None => {
                simple_log::warning!("Timed out while waiting for message!");
                Timer::after(Duration::from_millis(200)).await;
            },
            // Rest of the work
        }
    }
}
```

which is problematic because:

1. It requires a lot of clones.
2. I have to convert `recv()` into a `Future`.
3. I have to wrap it with a timeout.
4. Points 2 and 3 require additional dependencies.
5. This approach is bad for performance on low-power devices.

Instead, I would prefer to simply do this:

```rs
async fn message_loop(&self) {
    loop {
        match self.connection.try_recv() {
            None => {
                // Prevent busy-looping
                Timer::after(Duration::from_millis(50)).await;
            },
            // Rest of the work
        }
    }
}
```

which solves all the issues mentioned above.

This patch implements `try_recv` for the MavConnection trait, which allows users (like me) to have more control over their message receiving implementations. I looked at `AsyncMavConnection`, but as far as I can see it's non-blocking anyway. I am not sure why but it doesn't seem consistent with the `MavConnection` trait.