### PR TITLE
lock `actions/checkout` version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         ref: ${{ github.event.repository.default_branch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -16,10 +16,9 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-09-10
           components: clippy
       - uses: actions-rs-plus/clippy-check@v2
         with:
@@ -32,7 +31,7 @@ jobs:
           dialect: ["ardupilotmega", "asluav", "matrixpilot", "minimal", "paparazzi", "python_array_test", "standard", "test", "ualberta", "uavionix", "icarous", "common", "storm32", "csairlink", "loweheiser"]
           signing: ["", "--features signing"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Run internal tests
         run: cargo test --verbose --features ${{ matrix.dialect }} ${{ matrix.signing }} -- --nocapture
@@ -40,7 +39,7 @@ jobs:
   mavlink-dump:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Build mavlink-dump
         run: cargo build --verbose --example mavlink-dump
@@ -51,7 +50,7 @@ jobs:
       matrix:
         features: ["", "--features serde,tokio-1", "--features signing"]
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - name: Get MSRV from Cargo.toml
         run: |
           MSRV=$(grep 'rust-version' Cargo.toml | sed 's/.*= *"\(.*\)".*/\1/')
@@ -100,7 +99,7 @@ jobs:
     steps:
       - name: Building ${{ matrix.TARGET }}
         run: echo "${{ matrix.TARGET }}"
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           target: ${{ matrix.TARGET }}
@@ -114,7 +113,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           target: thumbv7em-none-eabihf
@@ -125,7 +124,7 @@ jobs:
     needs: internal-tests
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@nightly
     - name: Build docs
       run: cargo doc --features "default all-dialects emit-description emit-extensions format-generated-code tokio-1 signing" 


### PR DESCRIPTION
Locks `actions/checkout` to avoid relying on the latest available version, which might be broken or insecure.