### PR TITLE
Remove tokio sync feature

### DIFF
--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2.0", optional = true }
 serialport = { version = "4.7.2", default-features = false, optional = true }
 sha2 = { version = "0.10", optional = true }
-tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "sync", "fs"], optional = true }
+tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "fs"], optional = true }
 tokio-serial = { version = "5.4.4", default-features = false, optional = true }
 
 [features]


### PR DESCRIPTION
Likely minor oversight in #341:
The sync feature of tokio was only removed in `[dev-dependencies]` not the `[dependencies]`