### PR TITLE
String parsing for char[]

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -521,7 +521,7 @@ impl MavMessage {
                 // If sent by an implementation that doesn't have the extensions fields
                 // then the recipient will see zero values for the extensions fields.
                 let serde_default = if field.is_extension {
-                    if field.enumtype.is_some() {
+                    if field.enumtype.is_some() || matches!(field.mavtype, MavType::String(_)) {
                         quote!(#[cfg_attr(feature = "serde", serde(default))])
                     } else {
                         quote!(#[cfg_attr(feature = "serde", serde(default = "crate::RustDefault::rust_default"))])
@@ -866,6 +866,7 @@ pub enum MavType {
     Char,
     Float,
     Double,
+    String(usize),
     Array(Box<MavType>, usize),
 }
 
@@ -891,7 +892,11 @@ impl MavType {
                     let start = s.find('[')?;
                     let size = s[start + 1..(s.len() - 1)].parse::<usize>().ok()?;
                     let mtype = Self::parse_type(&s[0..start])?;
-                    Some(Array(Box::new(mtype), size))
+                    if mtype == Char {
+                        Some(String(size))
+                    } else {
+                        Some(Array(Box::new(mtype), size))
+                    }
                 } else {
                     None
                 }
@@ -915,7 +920,19 @@ impl MavType {
             Int64 => quote! {#val = #buf.get_i64_le();},
             Float => quote! {#val = #buf.get_f32_le();},
             Double => quote! {#val = #buf.get_f64_le();},
-            Array(t, _) => {
+            String(size) => {
+                let r = Char.rust_reader(&quote!(let next_char), buf);
+                quote! {
+                    for _ in 0..#size {
+                        #r
+                        if next_char == 0 {
+                            break;
+                        }
+                        #val.push(next_char as char);
+                    }
+                }
+            }
+            Array(t, _size) => {
                 let r = t.rust_reader(&quote!(let val), buf);
                 quote! {
                     for v in &mut #val {
@@ -943,6 +960,15 @@ impl MavType {
             UInt64 => quote! {#buf.put_u64_le(#val);},
             Int64 => quote! {#buf.put_i64_le(#val);},
             Double => quote! {#buf.put_f64_le(#val);},
+            String(_size) => {
+                let w = Char.rust_writer(&quote!(*val), buf);
+                quote! {
+                    let slice = #val.as_bytes();
+                    for val in slice {
+                        #w
+                    }
+                }
+            }
             Array(t, _size) => {
                 let w = t.rust_writer(&quote!(*val), buf);
                 quote! {
@@ -962,6 +988,7 @@ impl MavType {
             UInt16 | Int16 => 2,
             UInt32 | Int32 | Float => 4,
             UInt64 | Int64 | Double => 8,
+            String(size) => Char.len() * size,
             Array(t, size) => t.len() * size,
         }
     }
@@ -974,6 +1001,7 @@ impl MavType {
             UInt16 | Int16 => 2,
             UInt32 | Int32 | Float => 4,
             UInt64 | Int64 | Double => 8,
+            String(_) => Char.len(),
             Array(t, _) => t.len(),
         }
     }
@@ -994,6 +1022,7 @@ impl MavType {
             UInt64 => "uint64_t".into(),
             Int64 => "int64_t".into(),
             Double => "double".into(),
+            String(_) => "char".into(),
             Array(t, _) => t.primitive_type(),
         }
     }
@@ -1014,6 +1043,7 @@ impl MavType {
             UInt64 => "u64".into(),
             Int64 => "i64".into(),
             Double => "f64".into(),
+            String(size) => format!("arrayvec::ArrayString<{size}>"),
             Array(t, size) => format!("[{};{}]", t.rust_type(), size),
         }
     }
@@ -1032,6 +1062,7 @@ impl MavType {
             UInt64 => quote!(0_u64),
             Int64 => quote!(0_i64),
             Double => quote!(0.0_f64),
+            String(size) => quote!(arrayvec::ArrayString::<#size>::new_const()),
             Array(ty, size) => {
                 let default_value = ty.emit_default_value();
                 quote!([#default_value; #size])
@@ -1479,7 +1510,7 @@ pub fn extra_crc(msg: &MavMessage) -> u8 {
             crc.digest(field.name.as_bytes());
         }
         crc.digest(b" ");
-        if let MavType::Array(_, size) = field.mavtype {
+        if let MavType::String(size) | MavType::Array(_, size) = field.mavtype {
             crc.digest(&[size as u8]);
         }
     }

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2.0", optional = true }
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
+arrayvec = { version = "0.7.6", default-features = false }
 
 [features]
 default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega", "common"]
@@ -83,7 +84,7 @@ all-dialects = [
 format-generated-code = []
 emit-description = ["mavlink-bindgen/emit-description"]
 emit-extensions = ["mavlink-bindgen/emit-extensions"]
-std = ["mavlink-core/std"]
+std = ["mavlink-core/std", "arrayvec/std"]
 udp = ["mavlink-core/udp"]
 tcp = ["mavlink-core/tcp"]
 signing = ["mavlink-core/signing"]
@@ -93,7 +94,7 @@ direct-serial = ["mavlink-core/direct-serial"]
 # Use 'embedded-hal-0.2' feature to enable deprecated embedded-hal=0.2.3 (some hals is not supports embedded-hal=1.0 yet).
 embedded = ["mavlink-core/embedded"]
 embedded-hal-02 = ["mavlink-core/embedded-hal-02"]
-serde = ["bitflags/serde", "dep:serde", "dep:serde_arrays", "mavlink-core/serde"]
+serde = ["bitflags/serde", "dep:serde", "dep:serde_arrays", "mavlink-core/serde", "arrayvec/serde"]
 tokio-1 = ["mavlink-core/tokio-1"]
 arbitrary = ["dep:arbitrary", "dep:rand", "mavlink-bindgen/arbitrary", "mavlink-core/arbitrary"]
 

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -166,4 +166,42 @@ mod test_v2_encode_decode {
             }
         }
     }
+
+    pub const STATUSTEXT_V2: &[u8] = &[
+        mavlink::MAV_STX_V2,
+        0x06, // payload is 6 bytes.``
+        0x00,
+        0x00,
+        0x05,
+        0x2a,
+        0x04,
+        0xfd, // This is STATUSTEXT
+        0x00,
+        0x00,
+        0x02, // Severity
+        0x79, // "y"
+        0x6f, // "o"
+        0x75, // "u"
+        0x70, // "p"
+        0x69, // "i"
+        0x49, // CRC
+        0x00, // CRC
+    ];
+
+    /// It is in the V2 tests because of the trail of 0s that gets truncated at the end.
+    #[test]
+    pub fn test_read_string() {
+        let mut r = PeekReader::new(STATUSTEXT_V2);
+        let (_header, msg) = mavlink::read_v2_msg(&mut r).expect("Failed to parse message");
+
+        if let mavlink::common::MavMessage::STATUSTEXT(data) = msg {
+            assert_eq!(
+                data.severity,
+                mavlink::common::MavSeverity::MAV_SEVERITY_CRITICAL
+            );
+            assert_eq!(data.text.as_str(), "youpi");
+        } else {
+            panic!("Decoded wrong message type")
+        }
+    }
 }


### PR DESCRIPTION
> This allows messages like STATUSTEXT to parse nicely as an ArrayString in Rust.

I'm taking over #193 so we can implement the feature more quickly.