### PR TITLE
mavlink-bindgen: skip non XML files

### DIFF
--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -55,6 +55,11 @@ fn _generate(
         let definition_file = PathBuf::from(entry.file_name());
         let module_name = util::to_module_name(&definition_file);
 
+        // Skip non-XML files
+        if !definition_file.extension().is_some_and(|e| e == "xml") {
+            continue;
+        }
+
         let definition_rs = PathBuf::from(&module_name).with_extension("rs");
 
         let dest_path = destination_dir.join(definition_rs);


### PR DESCRIPTION
When running mavlink-bindgen in a directory that contains other files it fails. In my case it panicked when trying to "generate" bindings for `.git`. 

**Example directory**
```
mavlink
├── .git
├── all.xml
├── custom.xml
├── common.xml
├── minimal.xml
├── README.md
└── standard.xml
```

This PR adds a check when iterating over the entries in the directory to skip hidden files, directories and non-XML files. 