### PR TITLE
parser optimizations

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1651,18 +1651,25 @@ impl MavXmlFilter {
     }
 }
 
+#[inline(always)]
 fn to_pascal_case(text: impl AsRef<[u8]>) -> String {
-    text.as_ref()
-        .split(|c| *c == b'_')
-        .map(String::from_utf8_lossy)
-        .map(capitalize_word)
-        .collect()
-}
+    let input = text.as_ref();
+    let mut result = String::with_capacity(input.len());
+    let mut capitalize = true;
 
-fn capitalize_word(text: impl AsRef<str>) -> String {
-    let mut chars = text.as_ref().chars();
-    match chars.next() {
-        None => String::new(),
-        Some(char) => char.to_uppercase().to_string() + &chars.as_str().to_ascii_lowercase(),
+    for &b in input {
+        if b == b'_' {
+            capitalize = true;
+            continue;
+        }
+
+        if capitalize {
+            result.push((b as char).to_ascii_uppercase());
+            capitalize = false;
+        } else {
+            result.push((b as char).to_ascii_lowercase());
+        }
     }
+
+    result
 }

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1559,9 +1559,7 @@ impl Default for MavXmlFilter {
 
 impl MavXmlFilter {
     pub fn filter(&mut self, elements: &mut Vec<Result<Event, quick_xml::Error>>) {
-        // List of filters
-        elements.retain(|x| self.filter_extension(x));
-        elements.retain(|x| self.filter_messages(x))
+        elements.retain(|x| self.filter_extension(x) && self.filter_messages(x))
     }
 
     #[cfg(feature = "emit-extensions")]


### PR DESCRIPTION
`MavXmlFilter::filter` should be about twice as fast compared to the previous version, and invoking `to_pascal_case` should also be quite faster compared to the previous version as its inner logic is much cheaper and is now forced to be inlined (since it is frequently called in loops).