### PR TITLE
Add crate keywords and categories metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,9 @@ byteorder = { version = "1.3.4", default-features = false }
 [workspace.package]
 edition = "2021"
 rust-version = "1.70.0"
+keywords = ["mavlink", "parser", "protocol", "embedded"]
+categories = ["aerospace", "aerospace::protocols", "parsing", "embedded"]
+
+[workspace.lints.clippy]
+cargo = { level = "warn", priority = -1 }
+multiple_crate_versions  = "allow"

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -7,6 +7,8 @@ description = "Library used by rust-mavlink."
 readme = "README.md"
 repository = "https://github.com/mavlink/rust-mavlink"
 rust-version.workspace = true
+keywords = ['mavlink', 'cli', "generator", "parser", "xml"]
+categories.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -15,6 +15,8 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/mavlink/rust-mavlink"
 edition.workspace = true
 rust-version.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [dependencies]
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -17,6 +17,8 @@ license = "MIT/Apache-2.0"
 repository = "https://github.com/mavlink/rust-mavlink"
 edition.workspace = true
 rust-version.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [build-dependencies]
 mavlink-bindgen = { version = "=0.15.0", path = "../mavlink-bindgen", default-features = false }


### PR DESCRIPTION
Add missing categories and keywords cargo metadata values. Alternative suggestion for the actual values are welcome (see [valid categories](https://crates.io/category_slugs) and [popular keywords](https://crates.io/keywords), max 5 each).

`mavlink-bindgen` uses slightly different keywords to differentiate for its code-generation purpose.

Also enable the clippy [cargo lint group](https://rust-lang.github.io/rust-clippy/master/index.html?groups=cargo) except `multiple_crate_versions` is heavily reliant on dependencies using up to date versions of all crates.
The now enabled `cargo_common_metadata` lint catches missing metadata.