### PR TITLE
re-write entire codegen flow

### DIFF
--- a/mavlink-bindgen/README.md
+++ b/mavlink-bindgen/README.md
@@ -67,7 +67,7 @@ Add a `build/main.rs` or `build.rs` to your project if it does not already exist
 
 ```rs
 let out_dir = env::var("OUT_DIR").unwrap();
-let result = match mavlink_bindgen::generate(definitions_dir, out_dir) {
+let result = match mavlink_bindgen::generate(XmlDefinitions::Directory(definitions_dir), out_dir) {
     Ok(r) => r,
     Err(e) => {
         eprintln!("{e}");

--- a/mavlink-bindgen/src/cli.rs
+++ b/mavlink-bindgen/src/cli.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 use clap::Parser;
-use mavlink_bindgen::{emit_cargo_build_messages, format_generated_code, generate, BindGenError};
+use mavlink_bindgen::{
+    emit_cargo_build_messages, format_generated_code, generate, BindGenError, XmlDefinitions,
+};
 
 #[derive(Parser)]
 /// Generate Rust bindings from MAVLink message dialect XML files.
@@ -20,7 +22,10 @@ struct Cli {
 
 pub fn main() -> Result<(), BindGenError> {
     let args = Cli::parse();
-    let result = generate(args.definitions_dir, args.destination_dir)?;
+    let result = generate(
+        XmlDefinitions::Directory(args.definitions_dir),
+        args.destination_dir,
+    )?;
 
     if args.format_generated_code {
         format_generated_code(&result);

--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -1,6 +1,6 @@
 pub use crate::error::BindGenError;
 use std::fs::{read_dir, File};
-use std::io::BufWriter;
+use std::io::{self, BufWriter};
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -23,87 +23,163 @@ pub struct GeneratedBindings {
     pub mod_rs: PathBuf,
 }
 
-/// Generate Rust MAVLink dialect binding for dialects present in `definitions_dir` into `destination_dir`.
+/// Specifies the source(s) of MAVLink XML definition files used for generating
+/// Rust MAVLink dialect bindings.
+pub enum XmlDefinitions<T: AsRef<Path>> {
+    /// A collection of individual MAVLink XML definition files.
+    Files(Vec<T>),
+    /// A directory containing one or more MAVLink XML definition files.
+    Directory(T),
+}
+
+/// Generate Rust MAVLink dialect binding for dialects present in the given `xml_definitions`
+/// into `destination_dir`.
 ///
 /// If successful returns paths of generated bindings linked to their dialect definitions files.
 pub fn generate<P1: AsRef<Path>, P2: AsRef<Path>>(
-    definitions_dir: P1,
+    xml_definitions: XmlDefinitions<P1>,
     destination_dir: P2,
 ) -> Result<GeneratedBindings, BindGenError> {
-    _generate(definitions_dir.as_ref(), destination_dir.as_ref())
-}
+    let destination_dir = destination_dir.as_ref();
 
-fn _generate(
-    definitions_dir: &Path,
-    destination_dir: &Path,
-) -> Result<GeneratedBindings, BindGenError> {
     let mut bindings = vec![];
 
-    for entry_maybe in read_dir(definitions_dir).map_err(|source| {
-        BindGenError::CouldNotReadDefinitionsDirectory {
+    match xml_definitions {
+        XmlDefinitions::Files(files) => {
+            if files.is_empty() {
+                return Err(
+                    BindGenError::CouldNotReadDirectoryEntryInDefinitionsDirectory {
+                        source: io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            "At least one file must be given.",
+                        ),
+                        path: PathBuf::default(),
+                    },
+                );
+            }
+
+            for file in files {
+                let file = file.as_ref();
+
+                bindings.push(generate_single_file(file, destination_dir)?);
+            }
+        }
+        XmlDefinitions::Directory(definitions_dir) => {
+            let definitions_dir = definitions_dir.as_ref();
+
+            if !definitions_dir.is_dir() {
+                return Err(
+                    BindGenError::CouldNotReadDirectoryEntryInDefinitionsDirectory {
+                        source: io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("{} is not a directory.", definitions_dir.display()),
+                        ),
+                        path: definitions_dir.to_owned(),
+                    },
+                );
+            }
+
+            for entry_maybe in read_dir(definitions_dir).map_err(|source| {
+                BindGenError::CouldNotReadDefinitionsDirectory {
+                    source,
+                    path: definitions_dir.to_path_buf(),
+                }
+            })? {
+                let entry = entry_maybe.map_err(|source| {
+                    BindGenError::CouldNotReadDirectoryEntryInDefinitionsDirectory {
+                        source,
+                        path: definitions_dir.to_path_buf(),
+                    }
+                })?;
+
+                let definition_filename = PathBuf::from(entry.file_name());
+                // Skip non-XML files
+                if !definition_filename.extension().is_some_and(|e| e == "xml") {
+                    continue;
+                }
+
+                bindings.push(generate_single_file(&entry.path(), &destination_dir)?);
+            }
+        }
+    };
+
+    // Creating `mod.rs`
+    let dest_path = destination_dir.join("mod.rs");
+    let mut outf = File::create(&dest_path).map_err(|source| {
+        BindGenError::CouldNotCreateRustBindingsFile {
             source,
-            path: definitions_dir.to_path_buf(),
+            dest_path: dest_path.clone(),
         }
-    })? {
-        let entry = entry_maybe.map_err(|source| {
+    })?;
+
+    // generate code
+    binder::generate(
+        bindings
+            .iter()
+            .map(|binding| binding.module_name.deref())
+            .collect(),
+        &mut outf,
+    );
+
+    Ok(GeneratedBindings {
+        bindings,
+        mod_rs: dest_path,
+    })
+}
+
+/// Generate a Rust MAVLink dialect binding for the given `source_file` dialect into `destination_dir`.
+///
+/// If successful returns path of the generated binding linked to their dialect definition file.
+fn generate_single_file<P1: AsRef<Path>, P2: AsRef<Path>>(
+    source_file: P1,
+    destination_dir: P2,
+) -> Result<GeneratedBinding, BindGenError> {
+    let source_file = source_file.as_ref();
+    let destination_dir = destination_dir.as_ref();
+
+    let definitions_dir = source_file.parent().unwrap_or(Path::new(""));
+
+    if !source_file.exists() {
+        return Err(
             BindGenError::CouldNotReadDirectoryEntryInDefinitionsDirectory {
-                source,
-                path: definitions_dir.to_path_buf(),
-            }
-        })?;
-
-        let definition_file = PathBuf::from(entry.file_name());
-        let module_name = util::to_module_name(&definition_file);
-
-        // Skip non-XML files
-        if !definition_file.extension().is_some_and(|e| e == "xml") {
-            continue;
-        }
-
-        let definition_rs = PathBuf::from(&module_name).with_extension("rs");
-
-        let dest_path = destination_dir.join(definition_rs);
-        let mut outf = BufWriter::new(File::create(&dest_path).map_err(|source| {
-            BindGenError::CouldNotCreateRustBindingsFile {
-                source,
-                dest_path: dest_path.clone(),
-            }
-        })?);
-
-        // generate code
-        parser::generate(definitions_dir, &definition_file, &mut outf)?;
-
-        bindings.push(GeneratedBinding {
-            module_name,
-            mavlink_xml: entry.path(),
-            rust_module: dest_path,
-        });
-    }
-
-    // output mod.rs
-    {
-        let dest_path = destination_dir.join("mod.rs");
-        let mut outf = File::create(&dest_path).map_err(|source| {
-            BindGenError::CouldNotCreateRustBindingsFile {
-                source,
-                dest_path: dest_path.clone(),
-            }
-        })?;
-
-        // generate code
-        binder::generate(
-            bindings
-                .iter()
-                .map(|binding| binding.module_name.deref())
-                .collect(),
-            &mut outf,
+                source: io::Error::new(io::ErrorKind::NotFound, "File not found."),
+                path: definitions_dir.to_owned(),
+            },
         );
-
-        Ok(GeneratedBindings {
-            bindings,
-            mod_rs: dest_path,
-        })
     }
+
+    if !source_file.extension().is_some_and(|e| e == "xml") {
+        return Err(
+            BindGenError::CouldNotReadDirectoryEntryInDefinitionsDirectory {
+                source: io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "Non-XML files are not supported.",
+                ),
+                path: definitions_dir.to_owned(),
+            },
+        );
+    }
+
+    let definition_filename = PathBuf::from(source_file.file_name().unwrap());
+    let module_name = util::to_module_name(&definition_filename);
+    let definition_rs = PathBuf::from(&module_name).with_extension("rs");
+
+    let dest_path = destination_dir.join(definition_rs);
+    let mut outf = BufWriter::new(File::create(&dest_path).map_err(|source| {
+        BindGenError::CouldNotCreateRustBindingsFile {
+            source,
+            dest_path: dest_path.clone(),
+        }
+    })?);
+
+    // codegen
+    parser::generate(definitions_dir, &definition_filename, &mut outf)?;
+
+    Ok(GeneratedBinding {
+        module_name,
+        mavlink_xml: source_file.to_owned(),
+        rust_module: dest_path,
+    })
 }
 
 /// Formats generated code using `rustfmt`.

--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -1,5 +1,4 @@
 pub use crate::error::BindGenError;
-use std::env;
 use std::fs::{read_dir, File};
 use std::io::BufWriter;
 use std::ops::Deref;
@@ -40,10 +39,6 @@ fn _generate(
 ) -> Result<GeneratedBindings, BindGenError> {
     let mut bindings = vec![];
 
-    let enabled_features: Vec<String> = env::vars()
-        .filter_map(|(key, _)| key.strip_prefix("CARGO_FEATURE_").map(str::to_lowercase))
-        .collect();
-
     for entry_maybe in read_dir(definitions_dir).map_err(|source| {
         BindGenError::CouldNotReadDefinitionsDirectory {
             source,
@@ -59,12 +54,6 @@ fn _generate(
 
         let definition_file = PathBuf::from(entry.file_name());
         let module_name = util::to_module_name(&definition_file);
-
-        if !enabled_features.contains(&module_name) {
-            // No need to generate for features that aren't enabled.
-            // If feature is not enabled, users cannot use them anyway.
-            continue;
-        }
 
         // Skip non-XML files
         if !definition_file.extension().is_some_and(|e| e == "xml") {


### PR DESCRIPTION
Refactors codegen logic to handle both file lists and directories
as MAVLink XML sources.

This simplifies the codegen flow, improves error handling and allows
to generate dialects selectively when used as a library.

Reverts https://github.com/mavlink/rust-mavlink/pull/363
Fixes https://github.com/mavlink/rust-mavlink/issues/364