### PR TITLE
Fix arbitrary feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Run internal tests
-        run: cargo test --verbose --features ${{ matrix.dialect }} ${{ matrix.signing }} -- --nocapture
+        run: cargo test --verbose --features arbitrary,${{ matrix.dialect }} ${{ matrix.signing }} -- --nocapture
 
   mavlink-dump:
     runs-on: ubuntu-latest

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -51,7 +51,7 @@ embedded-hal-02 = ["dep:nb", "dep:embedded-hal-02"]
 serde = ["dep:serde", "dep:serde_arrays"]
 tokio-1 = ["dep:tokio", "dep:async-trait", "dep:tokio-serial", "dep:futures"]
 signing = ["dep:sha2"]
-"arbitrary" = ["dep:arbitrary", "dep:rand"]
+arbitrary = ["dep:arbitrary", "dep:rand"]
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "fs", "macros", "rt"] }

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -97,7 +97,7 @@ embedded = ["mavlink-core/embedded"]
 embedded-hal-02 = ["mavlink-core/embedded-hal-02"]
 serde = ["bitflags/serde", "dep:serde", "dep:serde_arrays", "mavlink-core/serde"]
 tokio-1 = ["mavlink-core/tokio-1"]
-arbitrary = ["dep:arbitrary", "dep:rand", "mavlink-bindgen/arbitrary", "mavlink-core/arbitrary"]
+arbitrary = ["dep:arbitrary", "dep:rand", "mavlink-bindgen/arbitrary", "mavlink-core/arbitrary", "bitflags/arbitrary"]
 
 # build with all features on docs.rs so that users viewing documentation
 # can see everything


### PR DESCRIPTION
Depends on #376 (merged)

This patch makes it build again for `--features=arbitrary`, and it also adds the feature to the tests so we don't break it again until we actually start using it in tests (implemented in the next PR).