### PR TITLE
Change return type on message functions to Option

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -284,11 +284,11 @@ impl MavProfile {
 
     fn emit_mav_message_id_from_name(&self, structs: &[TokenStream]) -> TokenStream {
         quote! {
-            fn message_id_from_name(name: &str) -> Result<u32, &'static str> {
+            fn message_id_from_name(name: &str) -> Option<u32> {
                 match name {
-                    #(#structs::NAME => Ok(#structs::ID),)*
+                    #(#structs::NAME => Some(#structs::ID),)*
                     _ => {
-                        Err("Invalid message name.")
+                        None
                     }
                 }
             }
@@ -301,11 +301,11 @@ impl MavProfile {
         structs: &[TokenStream],
     ) -> TokenStream {
         quote! {
-            fn default_message_from_id(id: u32) -> Result<Self, &'static str> {
+            fn default_message_from_id(id: u32) -> Option<Self> {
                 match id {
-                    #(#structs::ID => Ok(Self::#enums(#structs::default())),)*
+                    #(#structs::ID => Some(Self::#enums(#structs::default())),)*
                     _ => {
-                        Err("Invalid message id.")
+                        None
                     }
                 }
             }
@@ -319,10 +319,10 @@ impl MavProfile {
     ) -> TokenStream {
         quote! {
             #[cfg(feature = "arbitrary")]
-            fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Result<Self, &'static str> {
+            fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
                 match id {
-                    #(#structs::ID => Ok(Self::#enums(#structs::random(rng))),)*
-                    _ => Err("Invalid message id."),
+                    #(#structs::ID => Some(Self::#enums(#structs::random(rng))),)*
+                    _ => None,
                 }
             }
         }

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -134,13 +134,12 @@ where
     ) -> Result<Self, error::ParserError>;
 
     /// Return message id of specific message name
-    fn message_id_from_name(name: &str) -> Result<u32, &'static str>;
+    fn message_id_from_name(name: &str) -> Option<u32>;
     /// Return a default message of the speicfied message id
-    fn default_message_from_id(id: u32) -> Result<Self, &'static str>;
+    fn default_message_from_id(id: u32) -> Option<Self>;
     /// Return random valid message of the speicfied message id
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R)
-        -> Result<Self, &'static str>;
+    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self>;
     /// Return a message types [CRC_EXTRA byte](https://mavlink.io/en/guide/serialization.html#crc_extra)
     fn extra_crc(id: u32) -> u8;
 }

--- a/mavlink/tests/helper_tests.rs
+++ b/mavlink/tests/helper_tests.rs
@@ -5,12 +5,11 @@ mod helper_tests {
     #[test]
     fn test_get_default_message_from_id() {
         let message_name = "PING";
-        let id: std::result::Result<u32, &'static str> =
-            MavMessage::message_id_from_name(message_name);
+        let id: Option<u32> = MavMessage::message_id_from_name(message_name);
         let id = id.unwrap();
         assert!(id == 4, "Invalid id for message name: PING");
         let message = MavMessage::default_message_from_id(id);
-        if !matches!(message, Ok(MavMessage::PING(_))) {
+        if !matches!(message, Some(MavMessage::PING(_))) {
             unreachable!("Invalid message type.")
         }
         assert!(


### PR DESCRIPTION
`message_id_from_name()`, `default_message_from_id()` and `random_message_from_id()` only have one possible error: the message id or name does not exist, therefore `Option<_>` is a more appropriate type.