### PR TITLE
Fix `cargo doc` for stable rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,7 +128,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@nightly
     - name: Build docs
-      run: cargo doc --features "default all-dialects emit-description emit-extensions format-generated-code tokio-1 signing" 
+      run: RUSTDOCFLAGS=--cfg=docsrs cargo doc --features "default all-dialects emit-description emit-extensions format-generated-code tokio-1 signing" 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3
       if: ${{ github.ref == 'refs/heads/master' }}

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! [ardupilotmega::MavMessage]: https://docs.rs/mavlink/latest/mavlink/ardupilotmega/enum.MavMessage.html
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(any(docsrs, doc), not(doctest)), feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![deny(clippy::all)]
 #![warn(clippy::use_self)]
 

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -1,5 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(all(any(docsrs, doc), not(doctest)), feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Rust implementation of the MAVLink UAV messaging protocol, with bindings for all dialects.
 //! This crate provides message set code generation, packet building, parsing and connection handling for blocking and asynchronous I/O.


### PR DESCRIPTION
Fixes #361.

- only enable `doc_auto_cfg` feature for `docsrs` and no longer also for `doc`
- configure doc in the CI to use `--cfg=docsrs` to create documentation with nightly features as before (using the `doc_auto_cfg` feature)

Drawback is that simply using `cargo +nightly doc` will no longer enable the feature