### PR TITLE
Fix doc CI formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,8 @@ jobs:
     steps:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@nightly
+      with:
+        components: rustfmt
     - name: Build docs
       run: cargo doc --features "default all-dialects emit-description emit-extensions format-generated-code tokio-1 signing" 
     - name: Deploy

--- a/mavlink-bindgen/README.md
+++ b/mavlink-bindgen/README.md
@@ -48,7 +48,7 @@ Arguments:
   <DESTINATION_DIR>  Path to the directory where the code is generated into, must already exist
 
 Options:
-      --format-generated-code      format code generated code
+      --format-generated-code      format code generated code, requires rustfmt to be installed
       --emit-cargo-build-messages  prints cargo build message indicating when the code has to be rebuild
   -h, --help                       Print help
 ```

--- a/mavlink-bindgen/src/cli.rs
+++ b/mavlink-bindgen/src/cli.rs
@@ -12,7 +12,7 @@ struct Cli {
     definitions_dir: PathBuf,
     /// Path to the directory where the code is generated into, must already exist.
     destination_dir: PathBuf,
-    /// format code generated code
+    /// format code generated code, requires rustfmt to be installed
     #[arg(long)]
     format_generated_code: bool,
     /// prints cargo build messages indicating when the code has to be rebuild

--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -194,7 +194,15 @@ pub fn format_generated_code(result: &GeneratedBindings) {
         .arg(result.mod_rs.clone())
         .status()
     {
-        eprintln!("{error}");
+        if std::env::args()
+            .next()
+            .unwrap_or_default()
+            .contains("build-script-")
+        {
+            println!("cargo:warning=Failed to run rustfmt: {error}");
+        } else {
+            eprintln!("Failed to run rustfmt: {error}");
+        }
     }
 }
 

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -17,7 +17,7 @@
 //! - `embedded-hal-02`: Enables embedded support using version 0.2 of the [embedded-hal] crate, incompatible with `embedded`.
 //! - `tokio-1`: Enable support for asynchronous I/O using [tokio], incompatible with `embedded`.
 //! - `serde`: Enables [serde] support in generated message sets, enabled by default.
-//! - `format-generated-code`: Generated MAVLink message set code will be formatted.
+//! - `format-generated-code`: Generated MAVLink message set code will be formatted, requires `rustfmt` to be installed.
 //! - `emit-description`: Generated MAVLink message set code will include documentation.
 //! - `emit-extensions`: Generated MAVLink message set code will include [MAVLink 2 message extensions].
 //! - `arbitrary`: Enable support for the [arbitrary] crate.


### PR DESCRIPTION
Fixes #338
- The time of the docs Ci step went down from 21:09 in the last PR to 1:59 in this PR

The CI enviroment did not have rustfmt installed causing the `format_generated_code(..)` function to do nothing.
This PR:
- adds rustfmt to the CI
- document that rustfmt is required for this feature to work
- improve the error message, this will cause cargo to print a warning when running from a build script instead of using `eprintln!`. `eprintln!` is only visible with `-vv` and buried among a lot of other messages.

The warning message from the build script would look lithe this: 
```shell
$ cargo build -F "format-generated-code" 
   Compiling mavlink-bindgen v0.15.0 (/home/me/Documents/rust-mavlink/mavlink-bindgen)
   Compiling mavlink v0.15.0 (/home/me/Documents/rust-mavlink/mavlink)
warning: mavlink@0.15.0: Failed to run rustfmt: No such file or directory (os error 2)
```

The build script detection is somewhat hacky, alternatively we could 
- panic if rustfmt is not found with the feature enabled.
- change the return type of `format_generated_code` to `Result` and let the caller (either mavlink-bindgen/cli.rs or mavlink/build/main.rs) handle it. Since the 'neighbor' function `generate_single_file` was already changed this cycle this might be a good opportunity to do so.