### PR TITLE
Make generated order deterministic and add snapshot testing

### DIFF
--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -23,6 +23,7 @@ clap = { version = "~4.3.24", optional = true, default-features =false, features
 thiserror = { version = "2.0.12", default-features = false }
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
+indexmap = "2.11.0"
 
 # Required to support MSRV 1.65.0
 clap_lex = { version = "=0.7.5", optional=true }
@@ -38,3 +39,8 @@ cli = ["dep:clap", "dep:clap_lex", "dep:clap_builder", "dep:anstyle", "dep:ansty
 arbitrary = ["dep:arbitrary", "dep:rand"]
 emit-extensions = []
 emit-description = ["dep:regex"]
+serde = ["dep:serde", "indexmap/serde"]
+
+[dev-dependencies]
+insta = { version = "1.39.0", features = ["glob"] }
+tempfile = "3.10.1"

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -23,7 +23,6 @@ clap = { version = "~4.3.24", optional = true, default-features =false, features
 thiserror = { version = "2.0.12", default-features = false }
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
-indexmap = "2.11.0"
 
 # Required to support MSRV 1.65.0
 clap_lex = { version = "=0.7.5", optional=true }
@@ -39,7 +38,6 @@ cli = ["dep:clap", "dep:clap_lex", "dep:clap_builder", "dep:anstyle", "dep:ansty
 arbitrary = ["dep:arbitrary", "dep:rand"]
 emit-extensions = []
 emit-description = ["dep:regex"]
-serde = ["dep:serde", "indexmap/serde"]
 
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["glob"] }

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1,7 +1,7 @@
 use crc_any::CRCu16;
-use indexmap::{map::Entry, IndexMap};
 use std::cmp::Ordering;
-use std::collections::HashSet;
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashSet};
 use std::default::Default;
 use std::fs::File;
 use std::io::{BufReader, Write};
@@ -41,8 +41,8 @@ lazy_static! {
 #[derive(Debug, PartialEq, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MavProfile {
-    pub messages: IndexMap<String, MavMessage>,
-    pub enums: IndexMap<String, MavEnum>,
+    pub messages: BTreeMap<String, MavMessage>,
+    pub enums: BTreeMap<String, MavEnum>,
 }
 
 impl MavProfile {

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1,7 +1,7 @@
 use crc_any::CRCu16;
+use indexmap::{map::Entry, IndexMap};
 use std::cmp::Ordering;
-use std::collections::hash_map::Entry;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::default::Default;
 use std::fs::File;
 use std::io::{BufReader, Write};
@@ -41,8 +41,8 @@ lazy_static! {
 #[derive(Debug, PartialEq, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct MavProfile {
-    pub messages: HashMap<String, MavMessage>,
-    pub enums: HashMap<String, MavEnum>,
+    pub messages: IndexMap<String, MavMessage>,
+    pub enums: IndexMap<String, MavEnum>,
 }
 
 impl MavProfile {

--- a/mavlink-bindgen/tests/definitions/heartbeat.xml
+++ b/mavlink-bindgen/tests/definitions/heartbeat.xml
@@ -1,0 +1,12 @@
+<mavlink>
+    <messages>
+        <message id="0" name="HEARTBEAT">
+            <field type="uint32_t" name="custom_mode">Custom mode</field>
+            <field type="uint8_t" name="type">Type</field>
+            <field type="uint8_t" name="autopilot">Autopilot</field>
+            <field type="uint8_t" name="base_mode">Base mode</field>
+            <field type="uint8_t" name="system_status">System status</field>
+            <field type="uint8_t_mavlink_version" name="mavlink_version">Mavlink version</field>
+        </message>
+    </messages>
+</mavlink>

--- a/mavlink-bindgen/tests/definitions/parameters.xml
+++ b/mavlink-bindgen/tests/definitions/parameters.xml
@@ -1,0 +1,107 @@
+<mavlink>
+    <enums>
+        <enum name="MAV_PARAM_TYPE">
+            <description>Specifies the datatype of a MAVLink parameter.</description>
+            <entry value="1" name="MAV_PARAM_TYPE_UINT8">
+                <description>8-bit unsigned integer</description>
+            </entry>
+            <entry value="2" name="MAV_PARAM_TYPE_INT8">
+                <description>8-bit signed integer</description>
+            </entry>
+            <entry value="3" name="MAV_PARAM_TYPE_UINT16">
+                <description>16-bit unsigned integer</description>
+            </entry>
+            <entry value="4" name="MAV_PARAM_TYPE_INT16">
+                <description>16-bit signed integer</description>
+            </entry>
+            <entry value="5" name="MAV_PARAM_TYPE_UINT32">
+                <description>32-bit unsigned integer</description>
+            </entry>
+            <entry value="6" name="MAV_PARAM_TYPE_INT32">
+                <description>32-bit signed integer</description>
+            </entry>
+            <entry value="7" name="MAV_PARAM_TYPE_UINT64">
+                <description>64-bit unsigned integer</description>
+            </entry>
+            <entry value="8" name="MAV_PARAM_TYPE_INT64">
+                <description>64-bit signed integer</description>
+            </entry>
+            <entry value="9" name="MAV_PARAM_TYPE_REAL32">
+                <description>32-bit floating-point</description>
+            </entry>
+            <entry value="10" name="MAV_PARAM_TYPE_REAL64">
+                <description>64-bit floating-point</description>
+            </entry>
+        </enum>
+    </enums>
+    <messages>
+        <message id="20" name="PARAM_REQUEST_READ">
+            <description>Request to read the onboard parameter with the param_id string id. Onboard
+                parameters are stored as key[const char*] -&gt; value[float]. This allows to send a
+                parameter to any other component (such as the GCS) without the need of previous
+                knowledge of possible parameter names. Thus the same GCS can store different
+                parameters
+                for different autopilots. See also https://mavlink.io/en/services/parameter.html for
+                a
+                full documentation of QGroundControl and IMU code.</description>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
+            <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the
+                length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte
+                if
+                the length is exactly 16 chars - applications have to provide 16+1 bytes storage if
+                the
+                ID is stored as string</field>
+            <field type="int16_t" name="param_index" invalid="-1">Parameter index. Send -1 to use
+                the
+                param ID field as identifier (else the param id will be ignored)</field>
+        </message>
+        <message id="21" name="PARAM_REQUEST_LIST">
+            <description>Request all parameters of this component. After this request, all
+                parameters
+                are emitted. The parameter microservice is documented at
+                https://mavlink.io/en/services/parameter.html</description>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
+        </message>
+        <message id="22" name="PARAM_VALUE">
+            <description>Emit the value of a onboard parameter. The inclusion of param_count and
+                param_index in the message allows the recipient to keep track of received parameters
+                and
+                allows him to re-request missing parameters after a loss or timeout. The parameter
+                microservice is documented at https://mavlink.io/en/services/parameter.html</description>
+            <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the
+                length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte
+                if
+                the length is exactly 16 chars - applications have to provide 16+1 bytes storage if
+                the
+                ID is stored as string</field>
+            <field type="float" name="param_value">Onboard parameter value</field>
+            <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
+            <field type="uint16_t" name="param_count">Total number of onboard parameters</field>
+            <field type="uint16_t" name="param_index">Index of this onboard parameter</field>
+        </message>
+        <message id="23" name="PARAM_SET">
+            <description>Set a parameter value (write new value to permanent storage).
+                The receiving component should acknowledge the new parameter value by broadcasting a
+                PARAM_VALUE message (broadcasting ensures that multiple GCS all have an up-to-date
+                list
+                of all parameters). If the sending GCS did not receive a PARAM_VALUE within its
+                timeout
+                time, it should re-send the PARAM_SET message. The parameter microservice is
+                documented
+                at https://mavlink.io/en/services/parameter.html.
+            </description>
+            <field type="uint8_t" name="target_system">System ID</field>
+            <field type="uint8_t" name="target_component">Component ID</field>
+            <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the
+                length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte
+                if
+                the length is exactly 16 chars - applications have to provide 16+1 bytes storage if
+                the
+                ID is stored as string</field>
+            <field type="float" name="param_value">Onboard parameter value</field>
+            <field type="uint8_t" name="param_type" enum="MAV_PARAM_TYPE">Onboard parameter type.</field>
+        </message>
+    </messages>
+</mavlink>

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -1,0 +1,38 @@
+use std::fs;
+use std::path::PathBuf;
+
+use insta::{self, assert_snapshot, glob};
+use mavlink_bindgen::{format_generated_code, generate, XmlDefinitions};
+use tempfile::TempDir;
+
+fn definitions_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("definitions")
+}
+
+fn run_snapshot(def_file: &str) {
+    let defs = definitions_dir();
+    let tmp = TempDir::new().expect("tmp dir");
+    let out_dir = tmp.path();
+
+    let xml = defs.join(def_file);
+    let result = generate(XmlDefinitions::Files(vec![xml]), out_dir).expect("generate ok");
+
+    format_generated_code(&result);
+
+    glob!(out_dir, "**/*.rs", |path| {
+        let contents = fs::read_to_string(path).expect("read generated file");
+        assert_snapshot!(def_file, contents);
+    })
+}
+
+#[test]
+fn snapshot_heartbeat() {
+    run_snapshot("heartbeat.xml");
+}
+
+#[test]
+fn snapshot_parameters() {
+    run_snapshot("parameters.xml");
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
@@ -1,0 +1,184 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#![doc = "MAVLink heartbeat dialect."]
+#![doc = ""]
+#![doc = "This file was automatically generated, do not edit."]
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+#[allow(unused_imports)]
+use bitflags::bitflags;
+use mavlink_core::{bytes::Bytes, bytes_mut::BytesMut, MavlinkVersion, Message, MessageData};
+#[allow(unused_imports)]
+use num_derive::FromPrimitive;
+#[allow(unused_imports)]
+use num_derive::ToPrimitive;
+#[allow(unused_imports)]
+use num_traits::FromPrimitive;
+#[allow(unused_imports)]
+use num_traits::ToPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct HEARTBEAT_DATA {
+    pub custom_mode: u32,
+    pub mavtype: u8,
+    pub autopilot: u8,
+    pub base_mode: u8,
+    pub system_status: u8,
+    pub mavlink_version: u8,
+}
+impl HEARTBEAT_DATA {
+    pub const ENCODED_LEN: usize = 9usize;
+    pub const DEFAULT: Self = Self {
+        custom_mode: 0_u32,
+        mavtype: 0_u8,
+        autopilot: 0_u8,
+        base_mode: 0_u8,
+        system_status: 0_u8,
+        mavlink_version: 0_u8,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for HEARTBEAT_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for HEARTBEAT_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 0u32;
+    const NAME: &'static str = "HEARTBEAT";
+    const EXTRA_CRC: u8 = 50u8;
+    const ENCODED_LEN: usize = 9usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.custom_mode = buf.get_u32_le();
+        __struct.mavtype = buf.get_u8();
+        __struct.autopilot = buf.get_u8();
+        __struct.base_mode = buf.get_u8();
+        __struct.system_status = buf.get_u8();
+        __struct.mavlink_version = buf.get_u8();
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_u32_le(self.custom_mode);
+        __tmp.put_u8(self.mavtype);
+        __tmp.put_u8(self.autopilot);
+        __tmp.put_u8(self.base_mode);
+        __tmp.put_u8(self.system_status);
+        __tmp.put_u8(self.mavlink_version);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[repr(u32)]
+pub enum MavMessage {
+    HEARTBEAT(HEARTBEAT_DATA),
+}
+impl MavMessage {
+    pub const fn all_ids() -> &'static [u32] {
+        &[0u32]
+    }
+}
+impl Message for MavMessage {
+    fn parse(
+        version: MavlinkVersion,
+        id: u32,
+        payload: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        match id {
+            HEARTBEAT_DATA::ID => HEARTBEAT_DATA::deser(version, payload).map(Self::HEARTBEAT),
+            _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
+        }
+    }
+    fn message_name(&self) -> &'static str {
+        match self {
+            Self::HEARTBEAT(..) => HEARTBEAT_DATA::NAME,
+        }
+    }
+    fn message_id(&self) -> u32 {
+        match self {
+            Self::HEARTBEAT(..) => HEARTBEAT_DATA::ID,
+        }
+    }
+    fn message_id_from_name(name: &str) -> Option<u32> {
+        match name {
+            HEARTBEAT_DATA::NAME => Some(HEARTBEAT_DATA::ID),
+            _ => None,
+        }
+    }
+    fn default_message_from_id(id: u32) -> Option<Self> {
+        match id {
+            HEARTBEAT_DATA::ID => Some(Self::HEARTBEAT(HEARTBEAT_DATA::default())),
+            _ => None,
+        }
+    }
+    #[cfg(feature = "arbitrary")]
+    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+        match id {
+            HEARTBEAT_DATA::ID => Some(Self::HEARTBEAT(HEARTBEAT_DATA::random(rng))),
+            _ => None,
+        }
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        match self {
+            Self::HEARTBEAT(body) => body.ser(version, bytes),
+        }
+    }
+    fn extra_crc(id: u32) -> u8 {
+        match id {
+            HEARTBEAT_DATA::ID => HEARTBEAT_DATA::EXTRA_CRC,
+            _ => 0,
+        }
+    }
+    fn target_system_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+    fn target_component_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@mod.rs.snap
@@ -1,0 +1,13 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "heartbeat")]
+pub mod heartbeat;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@mod.rs.snap
@@ -1,0 +1,13 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "parameters")]
+pub mod parameters;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -1,0 +1,513 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#![doc = "MAVLink parameters dialect."]
+#![doc = ""]
+#![doc = "This file was automatically generated, do not edit."]
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+#[allow(unused_imports)]
+use bitflags::bitflags;
+use mavlink_core::{bytes::Bytes, bytes_mut::BytesMut, MavlinkVersion, Message, MessageData};
+#[allow(unused_imports)]
+use num_derive::FromPrimitive;
+#[allow(unused_imports)]
+use num_derive::ToPrimitive;
+#[allow(unused_imports)]
+use num_traits::FromPrimitive;
+#[allow(unused_imports)]
+use num_traits::ToPrimitive;
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[repr(u32)]
+pub enum MavParamType {
+    MAV_PARAM_TYPE_UINT8 = 1,
+    MAV_PARAM_TYPE_INT8 = 2,
+    MAV_PARAM_TYPE_UINT16 = 3,
+    MAV_PARAM_TYPE_INT16 = 4,
+    MAV_PARAM_TYPE_UINT32 = 5,
+    MAV_PARAM_TYPE_INT32 = 6,
+    MAV_PARAM_TYPE_UINT64 = 7,
+    MAV_PARAM_TYPE_INT64 = 8,
+    MAV_PARAM_TYPE_REAL32 = 9,
+    MAV_PARAM_TYPE_REAL64 = 10,
+}
+impl MavParamType {
+    pub const DEFAULT: Self = Self::MAV_PARAM_TYPE_UINT8;
+}
+impl Default for MavParamType {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_REQUEST_READ_DATA {
+    pub param_index: i16,
+    pub target_system: u8,
+    pub target_component: u8,
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
+    pub param_id: [u8; 16],
+}
+impl PARAM_REQUEST_READ_DATA {
+    pub const ENCODED_LEN: usize = 20usize;
+    pub const DEFAULT: Self = Self {
+        param_index: 0_i16,
+        target_system: 0_u8,
+        target_component: 0_u8,
+        param_id: [0_u8; 16usize],
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_REQUEST_READ_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_REQUEST_READ_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 20u32;
+    const NAME: &'static str = "PARAM_REQUEST_READ";
+    const EXTRA_CRC: u8 = 214u8;
+    const ENCODED_LEN: usize = 20usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.param_index = buf.get_i16_le();
+        __struct.target_system = buf.get_u8();
+        __struct.target_component = buf.get_u8();
+        for v in &mut __struct.param_id {
+            let val = buf.get_u8();
+            *v = val;
+        }
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_i16_le(self.param_index);
+        __tmp.put_u8(self.target_system);
+        __tmp.put_u8(self.target_component);
+        for val in &self.param_id {
+            __tmp.put_u8(*val);
+        }
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_REQUEST_LIST_DATA {
+    pub target_system: u8,
+    pub target_component: u8,
+}
+impl PARAM_REQUEST_LIST_DATA {
+    pub const ENCODED_LEN: usize = 2usize;
+    pub const DEFAULT: Self = Self {
+        target_system: 0_u8,
+        target_component: 0_u8,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_REQUEST_LIST_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_REQUEST_LIST_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 21u32;
+    const NAME: &'static str = "PARAM_REQUEST_LIST";
+    const EXTRA_CRC: u8 = 159u8;
+    const ENCODED_LEN: usize = 2usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.target_system = buf.get_u8();
+        __struct.target_component = buf.get_u8();
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_u8(self.target_system);
+        __tmp.put_u8(self.target_component);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_VALUE_DATA {
+    pub param_value: f32,
+    pub param_count: u16,
+    pub param_index: u16,
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
+    pub param_id: [u8; 16],
+    pub param_type: MavParamType,
+}
+impl PARAM_VALUE_DATA {
+    pub const ENCODED_LEN: usize = 25usize;
+    pub const DEFAULT: Self = Self {
+        param_value: 0.0_f32,
+        param_count: 0_u16,
+        param_index: 0_u16,
+        param_id: [0_u8; 16usize],
+        param_type: MavParamType::DEFAULT,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_VALUE_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_VALUE_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 22u32;
+    const NAME: &'static str = "PARAM_VALUE";
+    const EXTRA_CRC: u8 = 220u8;
+    const ENCODED_LEN: usize = 25usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.param_value = buf.get_f32_le();
+        __struct.param_count = buf.get_u16_le();
+        __struct.param_index = buf.get_u16_le();
+        for v in &mut __struct.param_id {
+            let val = buf.get_u8();
+            *v = val;
+        }
+        let tmp = buf.get_u8();
+        __struct.param_type =
+            FromPrimitive::from_u8(tmp).ok_or(::mavlink_core::error::ParserError::InvalidEnum {
+                enum_type: "MavParamType",
+                value: tmp as u32,
+            })?;
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_f32_le(self.param_value);
+        __tmp.put_u16_le(self.param_count);
+        __tmp.put_u16_le(self.param_index);
+        for val in &self.param_id {
+            __tmp.put_u8(*val);
+        }
+        __tmp.put_u8(self.param_type as u8);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_SET_DATA {
+    pub param_value: f32,
+    pub target_system: u8,
+    pub target_component: u8,
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
+    pub param_id: [u8; 16],
+    pub param_type: MavParamType,
+}
+impl PARAM_SET_DATA {
+    pub const ENCODED_LEN: usize = 23usize;
+    pub const DEFAULT: Self = Self {
+        param_value: 0.0_f32,
+        target_system: 0_u8,
+        target_component: 0_u8,
+        param_id: [0_u8; 16usize],
+        param_type: MavParamType::DEFAULT,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_SET_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_SET_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 23u32;
+    const NAME: &'static str = "PARAM_SET";
+    const EXTRA_CRC: u8 = 168u8;
+    const ENCODED_LEN: usize = 23usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.param_value = buf.get_f32_le();
+        __struct.target_system = buf.get_u8();
+        __struct.target_component = buf.get_u8();
+        for v in &mut __struct.param_id {
+            let val = buf.get_u8();
+            *v = val;
+        }
+        let tmp = buf.get_u8();
+        __struct.param_type =
+            FromPrimitive::from_u8(tmp).ok_or(::mavlink_core::error::ParserError::InvalidEnum {
+                enum_type: "MavParamType",
+                value: tmp as u32,
+            })?;
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_f32_le(self.param_value);
+        __tmp.put_u8(self.target_system);
+        __tmp.put_u8(self.target_component);
+        for val in &self.param_id {
+            __tmp.put_u8(*val);
+        }
+        __tmp.put_u8(self.param_type as u8);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[repr(u32)]
+pub enum MavMessage {
+    PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA),
+    PARAM_REQUEST_LIST(PARAM_REQUEST_LIST_DATA),
+    PARAM_VALUE(PARAM_VALUE_DATA),
+    PARAM_SET(PARAM_SET_DATA),
+}
+impl MavMessage {
+    pub const fn all_ids() -> &'static [u32] {
+        &[20u32, 21u32, 22u32, 23u32]
+    }
+}
+impl Message for MavMessage {
+    fn parse(
+        version: MavlinkVersion,
+        id: u32,
+        payload: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        match id {
+            PARAM_REQUEST_READ_DATA::ID => {
+                PARAM_REQUEST_READ_DATA::deser(version, payload).map(Self::PARAM_REQUEST_READ)
+            }
+            PARAM_REQUEST_LIST_DATA::ID => {
+                PARAM_REQUEST_LIST_DATA::deser(version, payload).map(Self::PARAM_REQUEST_LIST)
+            }
+            PARAM_VALUE_DATA::ID => {
+                PARAM_VALUE_DATA::deser(version, payload).map(Self::PARAM_VALUE)
+            }
+            PARAM_SET_DATA::ID => PARAM_SET_DATA::deser(version, payload).map(Self::PARAM_SET),
+            _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
+        }
+    }
+    fn message_name(&self) -> &'static str {
+        match self {
+            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::NAME,
+            Self::PARAM_REQUEST_LIST(..) => PARAM_REQUEST_LIST_DATA::NAME,
+            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::NAME,
+            Self::PARAM_SET(..) => PARAM_SET_DATA::NAME,
+        }
+    }
+    fn message_id(&self) -> u32 {
+        match self {
+            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::ID,
+            Self::PARAM_REQUEST_LIST(..) => PARAM_REQUEST_LIST_DATA::ID,
+            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::ID,
+            Self::PARAM_SET(..) => PARAM_SET_DATA::ID,
+        }
+    }
+    fn message_id_from_name(name: &str) -> Option<u32> {
+        match name {
+            PARAM_REQUEST_READ_DATA::NAME => Some(PARAM_REQUEST_READ_DATA::ID),
+            PARAM_REQUEST_LIST_DATA::NAME => Some(PARAM_REQUEST_LIST_DATA::ID),
+            PARAM_VALUE_DATA::NAME => Some(PARAM_VALUE_DATA::ID),
+            PARAM_SET_DATA::NAME => Some(PARAM_SET_DATA::ID),
+            _ => None,
+        }
+    }
+    fn default_message_from_id(id: u32) -> Option<Self> {
+        match id {
+            PARAM_REQUEST_READ_DATA::ID => {
+                Some(Self::PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA::default()))
+            }
+            PARAM_REQUEST_LIST_DATA::ID => {
+                Some(Self::PARAM_REQUEST_LIST(PARAM_REQUEST_LIST_DATA::default()))
+            }
+            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::default())),
+            PARAM_SET_DATA::ID => Some(Self::PARAM_SET(PARAM_SET_DATA::default())),
+            _ => None,
+        }
+    }
+    #[cfg(feature = "arbitrary")]
+    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+        match id {
+            PARAM_REQUEST_READ_DATA::ID => Some(Self::PARAM_REQUEST_READ(
+                PARAM_REQUEST_READ_DATA::random(rng),
+            )),
+            PARAM_REQUEST_LIST_DATA::ID => Some(Self::PARAM_REQUEST_LIST(
+                PARAM_REQUEST_LIST_DATA::random(rng),
+            )),
+            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::random(rng))),
+            PARAM_SET_DATA::ID => Some(Self::PARAM_SET(PARAM_SET_DATA::random(rng))),
+            _ => None,
+        }
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        match self {
+            Self::PARAM_REQUEST_READ(body) => body.ser(version, bytes),
+            Self::PARAM_REQUEST_LIST(body) => body.ser(version, bytes),
+            Self::PARAM_VALUE(body) => body.ser(version, bytes),
+            Self::PARAM_SET(body) => body.ser(version, bytes),
+        }
+    }
+    fn extra_crc(id: u32) -> u8 {
+        match id {
+            PARAM_REQUEST_READ_DATA::ID => PARAM_REQUEST_READ_DATA::EXTRA_CRC,
+            PARAM_REQUEST_LIST_DATA::ID => PARAM_REQUEST_LIST_DATA::EXTRA_CRC,
+            PARAM_VALUE_DATA::ID => PARAM_VALUE_DATA::EXTRA_CRC,
+            PARAM_SET_DATA::ID => PARAM_SET_DATA::EXTRA_CRC,
+            _ => 0,
+        }
+    }
+    fn target_system_id(&self) -> Option<u8> {
+        match self {
+            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_system),
+            Self::PARAM_REQUEST_LIST(inner) => Some(inner.target_system),
+            Self::PARAM_SET(inner) => Some(inner.target_system),
+            _ => None,
+        }
+    }
+    fn target_component_id(&self) -> Option<u8> {
+        match self {
+            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_component),
+            Self::PARAM_REQUEST_LIST(inner) => Some(inner.target_component),
+            Self::PARAM_SET(inner) => Some(inner.target_component),
+            _ => None,
+        }
+    }
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -48,6 +48,77 @@ impl Default for MavParamType {
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_REQUEST_LIST_DATA {
+    pub target_system: u8,
+    pub target_component: u8,
+}
+impl PARAM_REQUEST_LIST_DATA {
+    pub const ENCODED_LEN: usize = 2usize;
+    pub const DEFAULT: Self = Self {
+        target_system: 0_u8,
+        target_component: 0_u8,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_REQUEST_LIST_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_REQUEST_LIST_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 21u32;
+    const NAME: &'static str = "PARAM_REQUEST_LIST";
+    const EXTRA_CRC: u8 = 159u8;
+    const ENCODED_LEN: usize = 2usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.target_system = buf.get_u8();
+        __struct.target_component = buf.get_u8();
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_u8(self.target_system);
+        __tmp.put_u8(self.target_component);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 pub struct PARAM_REQUEST_READ_DATA {
     pub param_index: i16,
     pub target_system: u8,
@@ -122,171 +193,6 @@ impl MessageData for PARAM_REQUEST_READ_DATA {
         for val in &self.param_id {
             __tmp.put_u8(*val);
         }
-        if matches!(version, MavlinkVersion::V2) {
-            let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
-        } else {
-            __tmp.len()
-        }
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub struct PARAM_REQUEST_LIST_DATA {
-    pub target_system: u8,
-    pub target_component: u8,
-}
-impl PARAM_REQUEST_LIST_DATA {
-    pub const ENCODED_LEN: usize = 2usize;
-    pub const DEFAULT: Self = Self {
-        target_system: 0_u8,
-        target_component: 0_u8,
-    };
-    #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
-        use arbitrary::{Arbitrary, Unstructured};
-        let mut buf = [0u8; 1024];
-        rng.fill_bytes(&mut buf);
-        let mut unstructured = Unstructured::new(&buf);
-        Self::arbitrary(&mut unstructured).unwrap_or_default()
-    }
-}
-impl Default for PARAM_REQUEST_LIST_DATA {
-    fn default() -> Self {
-        Self::DEFAULT.clone()
-    }
-}
-impl MessageData for PARAM_REQUEST_LIST_DATA {
-    type Message = MavMessage;
-    const ID: u32 = 21u32;
-    const NAME: &'static str = "PARAM_REQUEST_LIST";
-    const EXTRA_CRC: u8 = 159u8;
-    const ENCODED_LEN: usize = 2usize;
-    fn deser(
-        _version: MavlinkVersion,
-        __input: &[u8],
-    ) -> Result<Self, ::mavlink_core::error::ParserError> {
-        let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
-        let mut buf = if avail_len < Self::ENCODED_LEN {
-            payload_buf[0..avail_len].copy_from_slice(__input);
-            Bytes::new(&payload_buf)
-        } else {
-            Bytes::new(__input)
-        };
-        let mut __struct = Self::default();
-        __struct.target_system = buf.get_u8();
-        __struct.target_component = buf.get_u8();
-        Ok(__struct)
-    }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
-        let mut __tmp = BytesMut::new(bytes);
-        #[allow(clippy::absurd_extreme_comparisons)]
-        #[allow(unused_comparisons)]
-        if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
-        }
-        __tmp.put_u8(self.target_system);
-        __tmp.put_u8(self.target_component);
-        if matches!(version, MavlinkVersion::V2) {
-            let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
-        } else {
-            __tmp.len()
-        }
-    }
-}
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub struct PARAM_VALUE_DATA {
-    pub param_value: f32,
-    pub param_count: u16,
-    pub param_index: u16,
-    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
-    pub param_id: [u8; 16],
-    pub param_type: MavParamType,
-}
-impl PARAM_VALUE_DATA {
-    pub const ENCODED_LEN: usize = 25usize;
-    pub const DEFAULT: Self = Self {
-        param_value: 0.0_f32,
-        param_count: 0_u16,
-        param_index: 0_u16,
-        param_id: [0_u8; 16usize],
-        param_type: MavParamType::DEFAULT,
-    };
-    #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
-        use arbitrary::{Arbitrary, Unstructured};
-        let mut buf = [0u8; 1024];
-        rng.fill_bytes(&mut buf);
-        let mut unstructured = Unstructured::new(&buf);
-        Self::arbitrary(&mut unstructured).unwrap_or_default()
-    }
-}
-impl Default for PARAM_VALUE_DATA {
-    fn default() -> Self {
-        Self::DEFAULT.clone()
-    }
-}
-impl MessageData for PARAM_VALUE_DATA {
-    type Message = MavMessage;
-    const ID: u32 = 22u32;
-    const NAME: &'static str = "PARAM_VALUE";
-    const EXTRA_CRC: u8 = 220u8;
-    const ENCODED_LEN: usize = 25usize;
-    fn deser(
-        _version: MavlinkVersion,
-        __input: &[u8],
-    ) -> Result<Self, ::mavlink_core::error::ParserError> {
-        let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
-        let mut buf = if avail_len < Self::ENCODED_LEN {
-            payload_buf[0..avail_len].copy_from_slice(__input);
-            Bytes::new(&payload_buf)
-        } else {
-            Bytes::new(__input)
-        };
-        let mut __struct = Self::default();
-        __struct.param_value = buf.get_f32_le();
-        __struct.param_count = buf.get_u16_le();
-        __struct.param_index = buf.get_u16_le();
-        for v in &mut __struct.param_id {
-            let val = buf.get_u8();
-            *v = val;
-        }
-        let tmp = buf.get_u8();
-        __struct.param_type =
-            FromPrimitive::from_u8(tmp).ok_or(::mavlink_core::error::ParserError::InvalidEnum {
-                enum_type: "MavParamType",
-                value: tmp as u32,
-            })?;
-        Ok(__struct)
-    }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
-        let mut __tmp = BytesMut::new(bytes);
-        #[allow(clippy::absurd_extreme_comparisons)]
-        #[allow(unused_comparisons)]
-        if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
-        }
-        __tmp.put_f32_le(self.param_value);
-        __tmp.put_u16_le(self.param_count);
-        __tmp.put_u16_le(self.param_index);
-        for val in &self.param_id {
-            __tmp.put_u8(*val);
-        }
-        __tmp.put_u8(self.param_type as u8);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
             ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
@@ -389,16 +295,110 @@ impl MessageData for PARAM_SET_DATA {
         }
     }
 }
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+pub struct PARAM_VALUE_DATA {
+    pub param_value: f32,
+    pub param_count: u16,
+    pub param_index: u16,
+    #[cfg_attr(feature = "serde", serde(with = "serde_arrays"))]
+    pub param_id: [u8; 16],
+    pub param_type: MavParamType,
+}
+impl PARAM_VALUE_DATA {
+    pub const ENCODED_LEN: usize = 25usize;
+    pub const DEFAULT: Self = Self {
+        param_value: 0.0_f32,
+        param_count: 0_u16,
+        param_index: 0_u16,
+        param_id: [0_u8; 16usize],
+        param_type: MavParamType::DEFAULT,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for PARAM_VALUE_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for PARAM_VALUE_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 22u32;
+    const NAME: &'static str = "PARAM_VALUE";
+    const EXTRA_CRC: u8 = 220u8;
+    const ENCODED_LEN: usize = 25usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.param_value = buf.get_f32_le();
+        __struct.param_count = buf.get_u16_le();
+        __struct.param_index = buf.get_u16_le();
+        for v in &mut __struct.param_id {
+            let val = buf.get_u8();
+            *v = val;
+        }
+        let tmp = buf.get_u8();
+        __struct.param_type =
+            FromPrimitive::from_u8(tmp).ok_or(::mavlink_core::error::ParserError::InvalidEnum {
+                enum_type: "MavParamType",
+                value: tmp as u32,
+            })?;
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        #[allow(clippy::absurd_extreme_comparisons)]
+        #[allow(unused_comparisons)]
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_f32_le(self.param_value);
+        __tmp.put_u16_le(self.param_count);
+        __tmp.put_u16_le(self.param_index);
+        for val in &self.param_id {
+            __tmp.put_u8(*val);
+        }
+        __tmp.put_u8(self.param_type as u8);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde", serde(tag = "type"))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[repr(u32)]
 pub enum MavMessage {
-    PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA),
     PARAM_REQUEST_LIST(PARAM_REQUEST_LIST_DATA),
-    PARAM_VALUE(PARAM_VALUE_DATA),
+    PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA),
     PARAM_SET(PARAM_SET_DATA),
+    PARAM_VALUE(PARAM_VALUE_DATA),
 }
 impl MavMessage {
     pub const fn all_ids() -> &'static [u32] {
@@ -412,100 +412,100 @@ impl Message for MavMessage {
         payload: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         match id {
-            PARAM_REQUEST_READ_DATA::ID => {
-                PARAM_REQUEST_READ_DATA::deser(version, payload).map(Self::PARAM_REQUEST_READ)
-            }
             PARAM_REQUEST_LIST_DATA::ID => {
                 PARAM_REQUEST_LIST_DATA::deser(version, payload).map(Self::PARAM_REQUEST_LIST)
             }
+            PARAM_REQUEST_READ_DATA::ID => {
+                PARAM_REQUEST_READ_DATA::deser(version, payload).map(Self::PARAM_REQUEST_READ)
+            }
+            PARAM_SET_DATA::ID => PARAM_SET_DATA::deser(version, payload).map(Self::PARAM_SET),
             PARAM_VALUE_DATA::ID => {
                 PARAM_VALUE_DATA::deser(version, payload).map(Self::PARAM_VALUE)
             }
-            PARAM_SET_DATA::ID => PARAM_SET_DATA::deser(version, payload).map(Self::PARAM_SET),
             _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
         }
     }
     fn message_name(&self) -> &'static str {
         match self {
-            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::NAME,
             Self::PARAM_REQUEST_LIST(..) => PARAM_REQUEST_LIST_DATA::NAME,
-            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::NAME,
+            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::NAME,
             Self::PARAM_SET(..) => PARAM_SET_DATA::NAME,
+            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::NAME,
         }
     }
     fn message_id(&self) -> u32 {
         match self {
-            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::ID,
             Self::PARAM_REQUEST_LIST(..) => PARAM_REQUEST_LIST_DATA::ID,
-            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::ID,
+            Self::PARAM_REQUEST_READ(..) => PARAM_REQUEST_READ_DATA::ID,
             Self::PARAM_SET(..) => PARAM_SET_DATA::ID,
+            Self::PARAM_VALUE(..) => PARAM_VALUE_DATA::ID,
         }
     }
     fn message_id_from_name(name: &str) -> Option<u32> {
         match name {
-            PARAM_REQUEST_READ_DATA::NAME => Some(PARAM_REQUEST_READ_DATA::ID),
             PARAM_REQUEST_LIST_DATA::NAME => Some(PARAM_REQUEST_LIST_DATA::ID),
-            PARAM_VALUE_DATA::NAME => Some(PARAM_VALUE_DATA::ID),
+            PARAM_REQUEST_READ_DATA::NAME => Some(PARAM_REQUEST_READ_DATA::ID),
             PARAM_SET_DATA::NAME => Some(PARAM_SET_DATA::ID),
+            PARAM_VALUE_DATA::NAME => Some(PARAM_VALUE_DATA::ID),
             _ => None,
         }
     }
     fn default_message_from_id(id: u32) -> Option<Self> {
         match id {
-            PARAM_REQUEST_READ_DATA::ID => {
-                Some(Self::PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA::default()))
-            }
             PARAM_REQUEST_LIST_DATA::ID => {
                 Some(Self::PARAM_REQUEST_LIST(PARAM_REQUEST_LIST_DATA::default()))
             }
-            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::default())),
+            PARAM_REQUEST_READ_DATA::ID => {
+                Some(Self::PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA::default()))
+            }
             PARAM_SET_DATA::ID => Some(Self::PARAM_SET(PARAM_SET_DATA::default())),
+            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::default())),
             _ => None,
         }
     }
     #[cfg(feature = "arbitrary")]
     fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
-            PARAM_REQUEST_READ_DATA::ID => Some(Self::PARAM_REQUEST_READ(
-                PARAM_REQUEST_READ_DATA::random(rng),
-            )),
             PARAM_REQUEST_LIST_DATA::ID => Some(Self::PARAM_REQUEST_LIST(
                 PARAM_REQUEST_LIST_DATA::random(rng),
             )),
-            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::random(rng))),
+            PARAM_REQUEST_READ_DATA::ID => Some(Self::PARAM_REQUEST_READ(
+                PARAM_REQUEST_READ_DATA::random(rng),
+            )),
             PARAM_SET_DATA::ID => Some(Self::PARAM_SET(PARAM_SET_DATA::random(rng))),
+            PARAM_VALUE_DATA::ID => Some(Self::PARAM_VALUE(PARAM_VALUE_DATA::random(rng))),
             _ => None,
         }
     }
     fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
         match self {
-            Self::PARAM_REQUEST_READ(body) => body.ser(version, bytes),
             Self::PARAM_REQUEST_LIST(body) => body.ser(version, bytes),
-            Self::PARAM_VALUE(body) => body.ser(version, bytes),
+            Self::PARAM_REQUEST_READ(body) => body.ser(version, bytes),
             Self::PARAM_SET(body) => body.ser(version, bytes),
+            Self::PARAM_VALUE(body) => body.ser(version, bytes),
         }
     }
     fn extra_crc(id: u32) -> u8 {
         match id {
-            PARAM_REQUEST_READ_DATA::ID => PARAM_REQUEST_READ_DATA::EXTRA_CRC,
             PARAM_REQUEST_LIST_DATA::ID => PARAM_REQUEST_LIST_DATA::EXTRA_CRC,
-            PARAM_VALUE_DATA::ID => PARAM_VALUE_DATA::EXTRA_CRC,
+            PARAM_REQUEST_READ_DATA::ID => PARAM_REQUEST_READ_DATA::EXTRA_CRC,
             PARAM_SET_DATA::ID => PARAM_SET_DATA::EXTRA_CRC,
+            PARAM_VALUE_DATA::ID => PARAM_VALUE_DATA::EXTRA_CRC,
             _ => 0,
         }
     }
     fn target_system_id(&self) -> Option<u8> {
         match self {
-            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_system),
             Self::PARAM_REQUEST_LIST(inner) => Some(inner.target_system),
+            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_system),
             Self::PARAM_SET(inner) => Some(inner.target_system),
             _ => None,
         }
     }
     fn target_component_id(&self) -> Option<u8> {
         match self {
-            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_component),
             Self::PARAM_REQUEST_LIST(inner) => Some(inner.target_component),
+            Self::PARAM_REQUEST_READ(inner) => Some(inner.target_component),
             Self::PARAM_SET(inner) => Some(inner.target_component),
             _ => None,
         }


### PR DESCRIPTION
This changes the hashmaps to indexmaps that preserve order of insertion when iterating over them. This makes the generated code order deterministic and consistent with the definition file. Before this, multiple runs would provide different orders for the generated structs and enums.

This PR also adds snapshot testing using [cargo insta](https://insta.rs/docs/) to ensure that the generated code remains consistent across changes or makes it very obvious when it does change. This should make PR reviews slightly easier because you can see changes to generated code in the PR diffs.

I've intentionally kept amount of messages being snapshot tested minimal. They can be added on a case by case basis after this PR to exercise different parts of the generator.