### PR TITLE
Use deprecation tags in message definition for code generation

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -112,6 +112,7 @@ impl MavProfile {
     //    }
 
     /// Simple header comment
+    #[inline(always)]
     fn emit_comments(&self, dialect_name: &str) -> TokenStream {
         let message = format!("MAVLink {dialect_name} dialect.");
         quote!(
@@ -122,15 +123,18 @@ impl MavProfile {
     }
 
     /// Emit rust messages
+    #[inline(always)]
     fn emit_msgs(&self) -> Vec<TokenStream> {
         self.messages.values().map(|d| d.emit_rust()).collect()
     }
 
     /// Emit rust enums
+    #[inline(always)]
     fn emit_enums(&self) -> Vec<TokenStream> {
         self.enums.values().map(|d| d.emit_rust()).collect()
     }
 
+    #[inline(always)]
     fn emit_deprecations(&self) -> Vec<TokenStream> {
         self.messages
             .values()
@@ -144,6 +148,7 @@ impl MavProfile {
     }
 
     /// Get list of original message names
+    #[inline(always)]
     fn emit_enum_names(&self) -> Vec<TokenStream> {
         self.messages
             .values()
@@ -155,6 +160,7 @@ impl MavProfile {
     }
 
     /// Emit message names with "_DATA" at the end
+    #[inline(always)]
     fn emit_struct_names(&self) -> Vec<TokenStream> {
         self.messages
             .values()
@@ -236,6 +242,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message(
         &self,
         deprecations: &[TokenStream],
@@ -253,6 +260,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_all_ids(&self) -> TokenStream {
         let mut message_ids = self.messages.values().map(|m| m.id).collect::<Vec<u32>>();
         message_ids.sort();
@@ -264,6 +272,7 @@ impl MavProfile {
         )
     }
 
+    #[inline(always)]
     fn emit_mav_message_parse(
         &self,
         enums: &[TokenStream],
@@ -283,6 +292,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_crc(&self, id_width: &Ident, structs: &[TokenStream]) -> TokenStream {
         quote! {
             fn extra_crc(id: #id_width) -> u8 {
@@ -296,6 +306,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_name(&self, enums: &[TokenStream], structs: &[TokenStream]) -> TokenStream {
         quote! {
             fn message_name(&self) -> &'static str {
@@ -306,6 +317,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_id(&self, enums: &[TokenStream], structs: &[TokenStream]) -> TokenStream {
         let id_width = format_ident!("u32");
         quote! {
@@ -317,6 +329,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_id_from_name(&self, structs: &[TokenStream]) -> TokenStream {
         quote! {
             fn message_id_from_name(name: &str) -> Option<u32> {
@@ -330,6 +343,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_default_from_id(
         &self,
         enums: &[TokenStream],
@@ -347,6 +361,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_random_from_id(
         &self,
         enums: &[TokenStream],
@@ -363,6 +378,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_serialize(&self, enums: &Vec<TokenStream>) -> TokenStream {
         quote! {
             fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
@@ -373,6 +389,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_target_system_id(&self) -> TokenStream {
         let arms: Vec<TokenStream> = self
             .messages
@@ -394,6 +411,7 @@ impl MavProfile {
         }
     }
 
+    #[inline(always)]
     fn emit_mav_message_target_component_id(&self) -> TokenStream {
         let arms: Vec<TokenStream> = self
             .messages
@@ -492,16 +510,19 @@ impl MavEnum {
             .collect()
     }
 
+    #[inline(always)]
     fn emit_name(&self) -> TokenStream {
         let name = format_ident!("{}", self.name);
         quote!(#name)
     }
 
+    #[inline(always)]
     fn emit_const_default(&self) -> TokenStream {
         let default = format_ident!("{}", self.entries[0].name);
         quote!(pub const DEFAULT: Self = Self::#default;)
     }
 
+    #[inline(always)]
     fn emit_deprecation(&self) -> TokenStream {
         self.deprecated
             .as_ref()
@@ -584,6 +605,7 @@ pub struct MavEnumEntry {
 }
 
 impl MavEnumEntry {
+    #[inline(always)]
     fn emit_deprecation(&self) -> TokenStream {
         self.deprecated
             .as_ref()
@@ -610,6 +632,7 @@ impl MavMessage {
         quote!(#name)
     }
 
+    #[inline(always)]
     fn emit_name_types(&self) -> (Vec<TokenStream>, usize) {
         let mut encoded_payload_len: usize = 0;
         let field_toks = self
@@ -657,6 +680,7 @@ impl MavMessage {
 
     /// Generate description for the given message
     #[cfg(feature = "emit-description")]
+    #[inline(always)]
     fn emit_description(&self) -> TokenStream {
         let mut ts = TokenStream::new();
         let desc = format!("id: {}", self.id);
@@ -674,6 +698,7 @@ impl MavMessage {
         ts
     }
 
+    #[inline(always)]
     fn emit_serialize_vars(&self) -> TokenStream {
         let ser_vars = self.fields.iter().map(|f| f.rust_writer());
 
@@ -707,6 +732,7 @@ impl MavMessage {
         }
     }
 
+    #[inline(always)]
     fn emit_deserialize_vars(&self) -> TokenStream {
         let deser_vars = self
             .fields
@@ -740,6 +766,7 @@ impl MavMessage {
         }
     }
 
+    #[inline(always)]
     fn emit_default_impl(&self) -> TokenStream {
         let msg_name = self.emit_struct_name();
         quote! {
@@ -751,6 +778,7 @@ impl MavMessage {
         }
     }
 
+    #[inline(always)]
     fn emit_deprecation(&self) -> TokenStream {
         self.deprecated
             .as_ref()
@@ -758,6 +786,7 @@ impl MavMessage {
             .unwrap_or_default()
     }
 
+    #[inline(always)]
     fn emit_const_default(&self) -> TokenStream {
         let initializers = self
             .fields
@@ -865,12 +894,14 @@ pub struct MavField {
 
 impl MavField {
     /// Emit rust name of a given field
+    #[inline(always)]
     fn emit_name(&self) -> TokenStream {
         let name = format_ident!("{}", self.name);
         quote!(#name)
     }
 
     /// Emit rust type of the field
+    #[inline(always)]
     fn emit_type(&self) -> TokenStream {
         let mavtype;
         if matches!(self.mavtype, MavType::Array(_, _)) {
@@ -888,6 +919,7 @@ impl MavField {
 
     /// Generate description for the given field
     #[cfg(feature = "emit-description")]
+    #[inline(always)]
     fn emit_description(&self) -> TokenStream {
         let mut ts = TokenStream::new();
         if let Some(val) = self.description.as_ref() {
@@ -898,6 +930,7 @@ impl MavField {
     }
 
     /// Combine rust name and type of a given field
+    #[inline(always)]
     fn emit_name_type(&self) -> TokenStream {
         let name = self.emit_name();
         let fieldtype = self.emit_type();
@@ -972,6 +1005,7 @@ impl MavField {
         }
     }
 
+    #[inline(always)]
     fn emit_default_initializer(&self) -> TokenStream {
         let field = self.emit_name();
         // FIXME: Is this actually expected behaviour??

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -453,11 +453,7 @@ impl MavEnum {
                 let name = format_ident!("{}", enum_entry.name.clone());
                 let value;
 
-                let deprecation = enum_entry
-                    .deprecated
-                    .as_ref()
-                    .map(|d| d.emit_tokens())
-                    .unwrap_or_default();
+                let deprecation = enum_entry.emit_deprecation();
 
                 #[cfg(feature = "emit-description")]
                 let description = if let Some(description) = enum_entry.description.as_ref() {
@@ -585,6 +581,15 @@ pub struct MavEnumEntry {
     pub description: Option<String>,
     pub params: Option<Vec<String>>,
     pub deprecated: Option<MavDeprecation>,
+}
+
+impl MavEnumEntry {
+    fn emit_deprecation(&self) -> TokenStream {
+        self.deprecated
+            .as_ref()
+            .map(|d| d.emit_tokens())
+            .unwrap_or_default()
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Default)]

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1204,9 +1204,9 @@ impl MavDeprecation {
     pub fn emit_tokens(&self) -> TokenStream {
         let since = &self.since;
         let note = match &self.note {
-            Some(str) if str.is_empty() || str.ends_with(".") => str,
-            Some(str) => &format!("{str}."),
-            None => &String::new(),
+            Some(str) if str.is_empty() || str.ends_with(".") => str.clone(),
+            Some(str) => format!("{str}."),
+            None => String::new(),
         };
         let replaced_by = if self.replaced_by.starts_with("`") {
             format!("See {}", self.replaced_by)

--- a/mavlink-bindgen/tests/definitions/deprecated.xml
+++ b/mavlink-bindgen/tests/definitions/deprecated.xml
@@ -1,0 +1,30 @@
+<mavlink>
+    <enums>
+        <enum name="MAV_FRAME">
+            <!-- ... -->
+            <entry value="5" name="MAV_FRAME_GLOBAL_INT">
+                <deprecated since="2024-03" replaced_by="MAV_FRAME_GLOBAL">Use MAV_FRAME_GLOBAL in COMMAND_INT (and elsewhere) as a synonymous replacement.</deprecated>
+                <description>Global (WGS84) coordinate frame (scaled) + altitude relative to mean sea level (MSL).</description>
+            </entry>
+            <!-- ... -->
+        </enum>
+        <enum name="MAV_MOUNT_MODE">
+            <deprecated since="2020-01" replaced_by="GIMBAL_MANAGER_FLAGS"/>
+            <description>Enumeration of possible mount operation modes. This message is used by obsolete/deprecated gimbal messages.</description>
+            <entry value="0" name="MAV_MOUNT_MODE_RETRACT">
+                <description>Load and keep safe position (Roll,Pitch,Yaw) from permanent memory and stop stabilization</description>
+            </entry>
+            <!-- ... -->
+        </enum>
+    </enums>
+    <messages>
+        <message id="4" name="PING">
+            <deprecated since="2011-08" replaced_by="TIMESYNC">To be removed / merged with TIMESYNC</deprecated>
+            <description>A ping message either requesting or responding to a ping. This allows to measure the system latencies, including serial port, radio modem and UDP connections. The ping microservice is documented at https://mavlink.io/en/services/ping.html</description>
+            <field type="uint64_t" name="time_usec" units="us">Timestamp (UNIX Epoch time or time since system boot). The receiving end can infer timestamp format (since 1.1.1970 or since system boot) by checking for the magnitude of the number.</field>
+            <field type="uint32_t" name="seq">PING sequence</field>
+            <field type="uint8_t" name="target_system">0: request ping from all receiving systems. If greater than 0: message is a ping response and number is the system id of the requesting system</field>
+            <field type="uint8_t" name="target_component">0: request ping from all receiving components. If greater than 0: message is a ping response and number is the component id of the requesting component.</field>
+        </message>
+    </messages>
+</mavlink>

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -36,3 +36,8 @@ fn snapshot_heartbeat() {
 fn snapshot_parameters() {
     run_snapshot("parameters.xml");
 }
+
+#[test]
+fn snapshot_deprecated() {
+    run_snapshot("deprecated.xml");
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
@@ -1,8 +1,9 @@
 ---
 source: mavlink-bindgen/tests/e2e_snapshots.rs
+assertion_line: 26
 expression: contents
 ---
-#![doc = "MAVLink heartbeat dialect."]
+#![doc = "MAVLink deprecated dialect."]
 #![doc = ""]
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
@@ -21,26 +22,57 @@ use num_traits::FromPrimitive;
 use num_traits::ToPrimitive;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[repr(u32)]
+pub enum MavFrame {
+    #[deprecated = "Use MAV_FRAME_GLOBAL in COMMAND_INT (and elsewhere) as a synonymous replacement. See `MAV_FRAME_GLOBAL` (Deprecated since 2024-03)"]
+    MAV_FRAME_GLOBAL_INT = 5,
+}
+impl MavFrame {
+    pub const DEFAULT: Self = Self::MAV_FRAME_GLOBAL_INT;
+}
+impl Default for MavFrame {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+#[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[repr(u32)]
+#[deprecated = " See `GIMBAL_MANAGER_FLAGS` (Deprecated since 2020-01)"]
+pub enum MavMountMode {
+    MAV_MOUNT_MODE_RETRACT = 0,
+}
+impl MavMountMode {
+    pub const DEFAULT: Self = Self::MAV_MOUNT_MODE_RETRACT;
+}
+impl Default for MavMountMode {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+#[deprecated = "To be removed / merged with TIMESYNC. See `TIMESYNC` (Deprecated since 2011-08)"]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
-pub struct HEARTBEAT_DATA {
-    pub custom_mode: u32,
-    pub mavtype: u8,
-    pub autopilot: u8,
-    pub base_mode: u8,
-    pub system_status: u8,
-    pub mavlink_version: u8,
+pub struct PING_DATA {
+    pub time_usec: u64,
+    pub seq: u32,
+    pub target_system: u8,
+    pub target_component: u8,
 }
-impl HEARTBEAT_DATA {
-    pub const ENCODED_LEN: usize = 9usize;
+impl PING_DATA {
+    pub const ENCODED_LEN: usize = 14usize;
     pub const DEFAULT: Self = Self {
-        custom_mode: 0_u32,
-        mavtype: 0_u8,
-        autopilot: 0_u8,
-        base_mode: 0_u8,
-        system_status: 0_u8,
-        mavlink_version: 0_u8,
+        time_usec: 0_u64,
+        seq: 0_u32,
+        target_system: 0_u8,
+        target_component: 0_u8,
     };
     #[cfg(feature = "arbitrary")]
     pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
@@ -51,17 +83,17 @@ impl HEARTBEAT_DATA {
         Self::arbitrary(&mut unstructured).unwrap_or_default()
     }
 }
-impl Default for HEARTBEAT_DATA {
+impl Default for PING_DATA {
     fn default() -> Self {
         Self::DEFAULT.clone()
     }
 }
-impl MessageData for HEARTBEAT_DATA {
+impl MessageData for PING_DATA {
     type Message = MavMessage;
-    const ID: u32 = 0u32;
-    const NAME: &'static str = "HEARTBEAT";
-    const EXTRA_CRC: u8 = 50u8;
-    const ENCODED_LEN: usize = 9usize;
+    const ID: u32 = 4u32;
+    const NAME: &'static str = "PING";
+    const EXTRA_CRC: u8 = 237u8;
+    const ENCODED_LEN: usize = 14usize;
     fn deser(
         _version: MavlinkVersion,
         __input: &[u8],
@@ -75,12 +107,10 @@ impl MessageData for HEARTBEAT_DATA {
             Bytes::new(__input)
         };
         let mut __struct = Self::default();
-        __struct.custom_mode = buf.get_u32_le();
-        __struct.mavtype = buf.get_u8();
-        __struct.autopilot = buf.get_u8();
-        __struct.base_mode = buf.get_u8();
-        __struct.system_status = buf.get_u8();
-        __struct.mavlink_version = buf.get_u8();
+        __struct.time_usec = buf.get_u64_le();
+        __struct.seq = buf.get_u32_le();
+        __struct.target_system = buf.get_u8();
+        __struct.target_component = buf.get_u8();
         Ok(__struct)
     }
     fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
@@ -94,12 +124,10 @@ impl MessageData for HEARTBEAT_DATA {
                 __tmp.remaining(),
             )
         }
-        __tmp.put_u32_le(self.custom_mode);
-        __tmp.put_u8(self.mavtype);
-        __tmp.put_u8(self.autopilot);
-        __tmp.put_u8(self.base_mode);
-        __tmp.put_u8(self.system_status);
-        __tmp.put_u8(self.mavlink_version);
+        __tmp.put_u64_le(self.time_usec);
+        __tmp.put_u32_le(self.seq);
+        __tmp.put_u8(self.target_system);
+        __tmp.put_u8(self.target_component);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
             ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
@@ -114,11 +142,12 @@ impl MessageData for HEARTBEAT_DATA {
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[repr(u32)]
 pub enum MavMessage {
-    HEARTBEAT(HEARTBEAT_DATA),
+    #[deprecated = "To be removed / merged with TIMESYNC. See `TIMESYNC` (Deprecated since 2011-08)"]
+    PING(PING_DATA),
 }
 impl MavMessage {
     pub const fn all_ids() -> &'static [u32] {
-        &[0u32]
+        &[4u32]
     }
 }
 impl Message for MavMessage {
@@ -128,57 +157,59 @@ impl Message for MavMessage {
         payload: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         match id {
-            HEARTBEAT_DATA::ID => HEARTBEAT_DATA::deser(version, payload).map(Self::HEARTBEAT),
+            PING_DATA::ID => PING_DATA::deser(version, payload).map(Self::PING),
             _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
         }
     }
     fn message_name(&self) -> &'static str {
         match self {
-            Self::HEARTBEAT(..) => HEARTBEAT_DATA::NAME,
+            Self::PING(..) => PING_DATA::NAME,
         }
     }
     fn message_id(&self) -> u32 {
         match self {
-            Self::HEARTBEAT(..) => HEARTBEAT_DATA::ID,
+            Self::PING(..) => PING_DATA::ID,
         }
     }
     fn message_id_from_name(name: &str) -> Option<u32> {
         match name {
-            HEARTBEAT_DATA::NAME => Some(HEARTBEAT_DATA::ID),
+            PING_DATA::NAME => Some(PING_DATA::ID),
             _ => None,
         }
     }
     fn default_message_from_id(id: u32) -> Option<Self> {
         match id {
-            HEARTBEAT_DATA::ID => Some(Self::HEARTBEAT(HEARTBEAT_DATA::default())),
+            PING_DATA::ID => Some(Self::PING(PING_DATA::default())),
             _ => None,
         }
     }
     #[cfg(feature = "arbitrary")]
     fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
-            HEARTBEAT_DATA::ID => Some(Self::HEARTBEAT(HEARTBEAT_DATA::random(rng))),
+            PING_DATA::ID => Some(Self::PING(PING_DATA::random(rng))),
             _ => None,
         }
     }
     fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
         match self {
-            Self::HEARTBEAT(body) => body.ser(version, bytes),
+            Self::PING(body) => body.ser(version, bytes),
         }
     }
     fn extra_crc(id: u32) -> u8 {
         match id {
-            HEARTBEAT_DATA::ID => HEARTBEAT_DATA::EXTRA_CRC,
+            PING_DATA::ID => PING_DATA::EXTRA_CRC,
             _ => 0,
         }
     }
     fn target_system_id(&self) -> Option<u8> {
         match self {
+            Self::PING(inner) => Some(inner.target_system),
             _ => None,
         }
     }
     fn target_component_id(&self) -> Option<u8> {
         match self {
+            Self::PING(inner) => Some(inner.target_component),
             _ => None,
         }
     }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@mod.rs.snap
@@ -1,0 +1,14 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+assertion_line: 26
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "deprecated")]
+pub mod deprecated;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -5,6 +5,7 @@ expression: contents
 #![doc = "MAVLink parameters dialect."]
 #![doc = ""]
 #![doc = "This file was automatically generated, do not edit."]
+#![allow(deprecated)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink/examples/mavlink-dump/src/main.rs
+++ b/mavlink/examples/mavlink-dump/src/main.rs
@@ -83,7 +83,7 @@ pub fn request_parameters() -> mavlink::ardupilotmega::MavMessage {
 
 /// Create a message enabling data streaming
 pub fn request_stream() -> mavlink::ardupilotmega::MavMessage {
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     mavlink::ardupilotmega::MavMessage::REQUEST_DATA_STREAM(
         mavlink::ardupilotmega::REQUEST_DATA_STREAM_DATA {
             target_system: 0,

--- a/mavlink/examples/mavlink-dump/src/main.rs
+++ b/mavlink/examples/mavlink-dump/src/main.rs
@@ -83,6 +83,7 @@ pub fn request_parameters() -> mavlink::ardupilotmega::MavMessage {
 
 /// Create a message enabling data streaming
 pub fn request_stream() -> mavlink::ardupilotmega::MavMessage {
+    #[allow(deprecated)]
     mavlink::ardupilotmega::MavMessage::REQUEST_DATA_STREAM(
         mavlink::ardupilotmega::REQUEST_DATA_STREAM_DATA {
             target_system: 0,

--- a/mavlink/tests/helper_tests.rs
+++ b/mavlink/tests/helper_tests.rs
@@ -9,7 +9,7 @@ mod helper_tests {
         let id = id.unwrap();
         assert!(id == 4, "Invalid id for message name: PING");
         let message = MavMessage::default_message_from_id(id);
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         if !matches!(message, Some(MavMessage::PING(_))) {
             unreachable!("Invalid message type.")
         }

--- a/mavlink/tests/helper_tests.rs
+++ b/mavlink/tests/helper_tests.rs
@@ -9,6 +9,7 @@ mod helper_tests {
         let id = id.unwrap();
         assert!(id == 4, "Invalid id for message name: PING");
         let message = MavMessage::default_message_from_id(id);
+        #[allow(deprecated)]
         if !matches!(message, Some(MavMessage::PING(_))) {
             unreachable!("Invalid message type.")
         }


### PR DESCRIPTION
In the MAVLink dialect files mesages, enums and enum fields can be marked as deprecated with 
`<deprecated since="YYYY-MM" replaced_by="...">optional description text</deprecated>` ([doc](https://mavlink.io/en/guide/xml_schema.html#deprecated)).

Currently if such a tag is encountered only a `eprintln!("TODO: deprecated {text}");` was used (is most cases at least).

This PR generates `#[deprecated = "..."]` attributes on all enums, enum values, message `*_DATA` structs and `MavMessage` enum entries that have such a tag.

I have also added a snapshot test that test a (shortened) example from common.xml for all 3 possible deprecated tag positions.

For the generated files to function as before without generating a lot of deprecation warnings they are now `#![allow(deprecated)]`. 

The documentation also says that some code-generators can optionally disable emitting deprecated messages enums and enum entries. This could also be done at a later point, for example with a by default enabled `emit-deprecated` feature.