### PR TITLE
Semicolon consistency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ categories = ["aerospace", "aerospace::protocols", "parsing", "embedded"]
 [workspace.lints.clippy]
 cargo = { level = "warn", priority = -1 }
 multiple_crate_versions  = "allow"
+semicolon_if_nothing_returned = "warn"
+unnecessary_semicolon = "warn"

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -42,3 +42,6 @@ emit-description = ["dep:regex"]
 [dev-dependencies]
 insta = { version = "1.39.0", features = ["glob"] }
 tempfile = "3.10.1"
+
+[lints] 
+workspace = true

--- a/mavlink-bindgen/src/lib.rs
+++ b/mavlink-bindgen/src/lib.rs
@@ -101,7 +101,7 @@ pub fn generate<P1: AsRef<Path>, P2: AsRef<Path>>(
                 bindings.push(generate_single_file(entry.path(), destination_dir)?);
             }
         }
-    };
+    }
 
     // Creating `mod.rs`
     let dest_path = destination_dir.join("mod.rs");

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -492,7 +492,7 @@ impl MavEnum {
                     cnt = cnt.max(tmp_value);
                     let tmp = TokenStream::from_str(&tmp_value.to_string()).unwrap();
                     value = quote!(#tmp);
-                };
+                }
                 if self.primitive.is_some() {
                     quote! {
                         #deprecation
@@ -1413,7 +1413,7 @@ pub fn parse_profile(
                             replaced_by: String::new(),
                             since: String::new(),
                             note: None,
-                        })
+                        });
                     }
                     _ => (),
                 }
@@ -1785,7 +1785,7 @@ impl Default for MavXmlFilter {
 
 impl MavXmlFilter {
     pub fn filter(&mut self, elements: &mut Vec<Result<Event, quick_xml::Error>>) {
-        elements.retain(|x| self.filter_extension(x) && self.filter_messages(x))
+        elements.retain(|x| self.filter_extension(x) && self.filter_messages(x));
     }
 
     #[cfg(feature = "emit-extensions")]

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -24,7 +24,7 @@ fn run_snapshot(def_file: &str) {
     glob!(out_dir, "**/*.rs", |path| {
         let contents = fs::read_to_string(path).expect("read generated file");
         assert_snapshot!(def_file, contents);
-    })
+    });
 }
 
 #[test]

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -55,3 +55,6 @@ arbitrary = ["dep:arbitrary", "dep:rand"]
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["io-util", "net", "fs", "macros", "rt"] }
+
+[lints] 
+workspace = true

--- a/mavlink-core/src/async_connection/direct_serial.rs
+++ b/mavlink-core/src/async_connection/direct_serial.rs
@@ -114,7 +114,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncSerialConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -123,7 +123,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncSerialConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -112,7 +112,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncFileConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -121,7 +121,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncFileConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -156,7 +156,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncTcpConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -165,7 +165,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncTcpConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/async_connection/udp.rs
+++ b/mavlink-core/src/async_connection/udp.rs
@@ -217,7 +217,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncUdpConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -226,7 +226,7 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncUdpConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/connection/direct_serial.rs
+++ b/mavlink-core/src/connection/direct_serial.rs
@@ -147,7 +147,7 @@ impl<M: Message> MavConnection<M> for SerialConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -156,7 +156,7 @@ impl<M: Message> MavConnection<M> for SerialConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/connection/file.rs
+++ b/mavlink-core/src/connection/file.rs
@@ -118,7 +118,7 @@ impl<M: Message> MavConnection<M> for FileConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -127,7 +127,7 @@ impl<M: Message> MavConnection<M> for FileConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/connection/tcp.rs
+++ b/mavlink-core/src/connection/tcp.rs
@@ -154,7 +154,7 @@ impl<M: Message> MavConnection<M> for TcpConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -163,7 +163,7 @@ impl<M: Message> MavConnection<M> for TcpConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/connection/udp.rs
+++ b/mavlink-core/src/connection/udp.rs
@@ -193,7 +193,7 @@ impl<M: Message> MavConnection<M> for UdpConnection {
     }
 
     fn set_allow_recv_any_version(&mut self, allow: bool) {
-        self.recv_any_version = allow
+        self.recv_any_version = allow;
     }
 
     fn allow_recv_any_version(&self) -> bool {
@@ -202,7 +202,7 @@ impl<M: Message> MavConnection<M> for UdpConnection {
 
     #[cfg(feature = "signing")]
     fn setup_signing(&mut self, signing_data: Option<SigningConfig>) {
-        self.signing_data = signing_data.map(SigningData::from_config)
+        self.signing_data = signing_data.map(SigningData::from_config);
     }
 }
 

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -723,7 +723,7 @@ pub fn read_v1_raw_message<M: Message, R: Read>(
 
         if let Some(msg) = try_decode_v1::<M, _>(reader)? {
             return Ok(msg);
-        };
+        }
 
         reader.consume(1);
     }

--- a/mavlink-core/src/signing.rs
+++ b/mavlink-core/src/signing.rs
@@ -109,7 +109,7 @@ impl SigningData {
             if result {
                 // if signature is valid update timestamps
                 state.stream_timestamps.insert(stream_key, timestamp);
-                state.timestamp = u64::max(state.timestamp, timestamp)
+                state.timestamp = u64::max(state.timestamp, timestamp);
             }
             result
         } else {

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -116,3 +116,6 @@ features = [
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "time" ] }
 serde_test = "1.0"
+
+[lints] 
+workspace = true

--- a/mavlink/tests/agnostic_decode_test.rs
+++ b/mavlink/tests/agnostic_decode_test.rs
@@ -71,7 +71,7 @@ mod test_agnostic_encode_decode {
         assert!(
             mavlink::read_any_msg::<mavlink::common::MavMessage, _>(&mut r).is_err(),
             "Parsed message from garbage data"
-        )
+        );
     }
 }
 
@@ -138,6 +138,6 @@ mod test_agnostic_encode_decode_async {
                 .await
                 .is_err(),
             "Parsed message from garbage data"
-        )
+        );
     }
 }


### PR DESCRIPTION
- enable `semicolon_if_nothing_returned` and `unnecessary_semicolon` clippy lints
- fix any occurrences
- fix workspace lint config, the lint config in the workspace `Cargo.toml` are now properly used in all 3 crates

The lints as applied make it so that
- the body of any function returning nothing should end with `;`
- any blocks that returns nothing should not be followed by a `;` 