### PR TITLE
Hide `bytes` and `bytes_mut` in doc

### DIFF
--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -43,7 +43,9 @@ use crate::{bytes::Bytes, error::ParserError};
 
 use crc_any::CRCu16;
 
+#[doc(hidden)]
 pub mod bytes;
+#[doc(hidden)]
 pub mod bytes_mut;
 #[cfg(feature = "std")]
 mod connection;


### PR DESCRIPTION
These are not intended to be a part of the public api, they are only `pub` so they can be used by the generated dialect code.