### PR TITLE
Properly handle message ids over 255 for MAVLink 1

### DIFF
--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -91,6 +91,8 @@ pub enum MessageWriteError {
     /// IO Error while writing
     #[cfg(any(feature = "embedded", feature = "embedded-hal-02"))]
     Io,
+    /// Message does not support MAVLink 1
+    MAVLink2Only,
 }
 
 impl Display for MessageWriteError {
@@ -100,6 +102,7 @@ impl Display for MessageWriteError {
             Self::Io(e) => write!(f, "Failed to write message: {e:#?}"),
             #[cfg(any(feature = "embedded", feature = "embedded-hal-02"))]
             Self::Io => write!(f, "Failed to write message"),
+            Self::MAVLink2Only => write!(f, "Message is not supported in MAVLink 1"),
         }
     }
 }

--- a/mavlink/tests/v1_encode_decode_tests.rs
+++ b/mavlink/tests/v1_encode_decode_tests.rs
@@ -152,4 +152,21 @@ mod test_v1_encode_decode {
             panic!("Read invalid message")
         }
     }
+
+    #[test]
+    pub fn test_overflowing_msg_id() {
+        // test behaivior for message ids that are not valid for MAVLink 1
+        let msg_data = mavlink::common::MavMessage::SETUP_SIGNING(
+            mavlink::common::SETUP_SIGNING_DATA::default(),
+        );
+        let mut buf = vec![];
+        assert!(
+            matches!(
+                mavlink::write_v1_msg(&mut buf, crate::test_shared::COMMON_MSG_HEADER, &msg_data,),
+                Err(mavlink::error::MessageWriteError::MAVLink2Only)
+            ),
+            "Writing a message with id 256 should return an error for MAVLink 1"
+        );
+        assert!(buf.is_empty(), "No bytes should be written");
+    }
 }


### PR DESCRIPTION
Currently writing a message with an id over 255 with MAVLink 1 will overflow the message id and subsequently send the data as normal. Due a CRC_EXTRA missmatch it is unlikely that the data will be received as valid but it is sent either way.

There does not seem to be a definition what should happen in such case in the standard and the reference implementations seem to handle it differently (python crashes, C seems to also overflow the ID) but either returning an error or panicing seem like valid. 

This PR makes it so that 
- the `write_v1_msg` functions returns a `MessageWriteError::MAVLink2Only`  and
- the lower level  `serialize_message` functions panic 

when attempting to write a message with an id over 255. 