### PR TITLE
Panic and error documentation

### DIFF
--- a/mavlink-core/src/async_connection/direct_serial.rs
+++ b/mavlink-core/src/async_connection/direct_serial.rs
@@ -14,10 +14,12 @@ use crate::MAVLinkMessageRaw;
 use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Message, ReadVersion};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{
+    read_versioned_msg_async, read_versioned_raw_message_async, write_versioned_msg_async,
+};
 #[cfg(feature = "signing")]
 use crate::{
-    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
+    read_versioned_msg_async_signed, read_versioned_raw_message_async_signed,
     write_versioned_msg_async_signed, SigningConfig, SigningData,
 };
 

--- a/mavlink-core/src/async_connection/direct_serial.rs
+++ b/mavlink-core/src/async_connection/direct_serial.rs
@@ -14,10 +14,10 @@ use crate::MAVLinkMessageRaw;
 use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Message, ReadVersion};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
 #[cfg(feature = "signing")]
 use crate::{
-    read_raw_versioned_msg_async_signed, read_versioned_msg_async_signed,
+    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
     write_versioned_msg_async_signed, SigningConfig, SigningData,
 };
 
@@ -50,9 +50,9 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncSerialConnection {
         let mut port = self.port.lock().await;
         let version = ReadVersion::from_async_conn_cfg::<_, M>(self);
         #[cfg(not(feature = "signing"))]
-        let result = read_raw_versioned_msg_async::<M, _>(port.deref_mut(), version).await;
+        let result = read_versioned_raw_message_async::<M, _>(port.deref_mut(), version).await;
         #[cfg(feature = "signing")]
-        let result = read_raw_versioned_msg_async_signed::<M, _>(
+        let result = read_versioned_raw_message_async_signed::<M, _>(
             port.deref_mut(),
             version,
             self.signing_data.as_ref(),

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -16,11 +16,11 @@ use futures::lock::Mutex;
 use tokio::fs::File;
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message_async, read_versioned_msg_async};
+use crate::{read_versioned_msg_async, read_versioned_raw_message_async};
 
 #[cfg(feature = "signing")]
 use crate::{
-    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed, SigningConfig,
+    read_versioned_msg_async_signed, read_versioned_raw_message_async_signed, SigningConfig,
     SigningData,
 };
 

--- a/mavlink-core/src/async_connection/file.rs
+++ b/mavlink-core/src/async_connection/file.rs
@@ -16,11 +16,11 @@ use futures::lock::Mutex;
 use tokio::fs::File;
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg_async, read_versioned_msg_async};
+use crate::{read_versioned_raw_message_async, read_versioned_msg_async};
 
 #[cfg(feature = "signing")]
 use crate::{
-    read_raw_versioned_msg_async_signed, read_versioned_msg_async_signed, SigningConfig,
+    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed, SigningConfig,
     SigningData,
 };
 
@@ -50,9 +50,9 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncFileConnection {
         let version = ReadVersion::from_async_conn_cfg::<_, M>(self);
         loop {
             #[cfg(not(feature = "signing"))]
-            let result = read_raw_versioned_msg_async::<M, _>(file.deref_mut(), version).await;
+            let result = read_versioned_raw_message_async::<M, _>(file.deref_mut(), version).await;
             #[cfg(feature = "signing")]
-            let result = read_raw_versioned_msg_async_signed::<M, _>(
+            let result = read_versioned_raw_message_async_signed::<M, _>(
                 file.deref_mut(),
                 version,
                 self.signing_data.as_ref(),

--- a/mavlink-core/src/async_connection/mod.rs
+++ b/mavlink-core/src/async_connection/mod.rs
@@ -94,6 +94,13 @@ pub trait AsyncMavConnection<M: Message + Sync + Send> {
 ///
 /// The type of the connection is determined at runtime based on the address type, so the
 /// connection is returned as a trait object.
+///
+/// # Errors
+///
+/// - [`AddrNotAvailable`] if the address string could not be parsed as a valid MAVLink address
+/// - When the connection could not be established a corresponding [`io::Error`] is returned
+///
+/// [`AddrNotAvailable`]: io::ErrorKind::AddrNotAvailable
 pub async fn connect_async<M: Message + Sync + Send>(
     address: &str,
 ) -> io::Result<Box<dyn AsyncMavConnection<M> + Sync + Send>> {

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -14,10 +14,10 @@ use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
 #[cfg(feature = "signing")]
 use crate::{
-    read_raw_versioned_msg_async_signed, read_versioned_msg_async_signed,
+    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
     write_versioned_msg_async_signed, SigningConfig, SigningData,
 };
 
@@ -107,9 +107,9 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncTcpConnection {
         let mut reader = self.reader.lock().await;
         let version = ReadVersion::from_async_conn_cfg::<_, M>(self);
         #[cfg(not(feature = "signing"))]
-        let result = read_raw_versioned_msg_async::<M, _>(reader.deref_mut(), version).await;
+        let result = read_versioned_raw_message_async::<M, _>(reader.deref_mut(), version).await;
         #[cfg(feature = "signing")]
-        let result = read_raw_versioned_msg_async_signed::<M, _>(
+        let result = read_versioned_raw_message_async_signed::<M, _>(
             reader.deref_mut(),
             version,
             self.signing_data.as_ref(),

--- a/mavlink-core/src/async_connection/tcp.rs
+++ b/mavlink-core/src/async_connection/tcp.rs
@@ -14,10 +14,12 @@ use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{
+    read_versioned_msg_async, read_versioned_raw_message_async, write_versioned_msg_async,
+};
 #[cfg(feature = "signing")]
 use crate::{
-    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
+    read_versioned_msg_async_signed, read_versioned_raw_message_async_signed,
     write_versioned_msg_async_signed, SigningConfig, SigningData,
 };
 

--- a/mavlink-core/src/async_connection/udp.rs
+++ b/mavlink-core/src/async_connection/udp.rs
@@ -18,10 +18,12 @@ use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Messa
 use super::{get_socket_addr, AsyncConnectable, AsyncMavConnection};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{
+    read_versioned_msg_async, read_versioned_raw_message_async, write_versioned_msg_async,
+};
 #[cfg(feature = "signing")]
 use crate::{
-    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
+    read_versioned_msg_async_signed, read_versioned_raw_message_async_signed,
     write_versioned_msg_signed, SigningConfig, SigningData,
 };
 
@@ -144,7 +146,8 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncUdpConnection {
         let version = ReadVersion::from_async_conn_cfg::<_, M>(self);
         loop {
             #[cfg(not(feature = "signing"))]
-            let result = read_versioned_raw_message_async::<M, _>(reader.deref_mut(), version).await;
+            let result =
+                read_versioned_raw_message_async::<M, _>(reader.deref_mut(), version).await;
             #[cfg(feature = "signing")]
             let result = read_versioned_raw_message_async_signed::<M, _>(
                 reader.deref_mut(),

--- a/mavlink-core/src/async_connection/udp.rs
+++ b/mavlink-core/src/async_connection/udp.rs
@@ -18,10 +18,10 @@ use crate::{async_peek_reader::AsyncPeekReader, MavHeader, MavlinkVersion, Messa
 use super::{get_socket_addr, AsyncConnectable, AsyncMavConnection};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg_async, read_versioned_msg_async, write_versioned_msg_async};
+use crate::{read_versioned_raw_message_async, read_versioned_msg_async, write_versioned_msg_async};
 #[cfg(feature = "signing")]
 use crate::{
-    read_raw_versioned_msg_async_signed, read_versioned_msg_async_signed,
+    read_versioned_raw_message_async_signed, read_versioned_msg_async_signed,
     write_versioned_msg_signed, SigningConfig, SigningData,
 };
 
@@ -144,9 +144,9 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncUdpConnection {
         let version = ReadVersion::from_async_conn_cfg::<_, M>(self);
         loop {
             #[cfg(not(feature = "signing"))]
-            let result = read_raw_versioned_msg_async::<M, _>(reader.deref_mut(), version).await;
+            let result = read_versioned_raw_message_async::<M, _>(reader.deref_mut(), version).await;
             #[cfg(feature = "signing")]
-            let result = read_raw_versioned_msg_async_signed::<M, _>(
+            let result = read_versioned_raw_message_async_signed::<M, _>(
                 reader.deref_mut(),
                 version,
                 self.signing_data.as_ref(),

--- a/mavlink-core/src/async_peek_reader.rs
+++ b/mavlink-core/src/async_peek_reader.rs
@@ -57,11 +57,17 @@ impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFE
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function does not consume data from the buffer, so subsequent calls to `peek` or `read` functions
     /// will still return the peeked data.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`tokio::io::AsyncReadExt`] it is returned
+    /// - If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic when attempting to read more bytes then `BUFFER_SIZE`
     pub async fn peek_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
         self.fetch(amount, false).await
     }
@@ -71,10 +77,16 @@ impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFE
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`tokio::io::AsyncReadExt`] it is returned
+    /// - If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic when attempting to read more bytes then `BUFFER_SIZE`
     pub async fn read_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
         self.fetch(amount, true).await
     }
@@ -84,10 +96,16 @@ impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFE
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`tokio::io::AsyncReadExt`] until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`tokio::io::AsyncReadExt`] it is returned
+    /// - If an EOF occurs before a byte could be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will always panic if `BUFFER_SIZE` is 0.  
     pub async fn read_u8(&mut self) -> Result<u8, MessageReadError> {
         let buf = self.read_exact(1).await?;
         Ok(buf[0])

--- a/mavlink-core/src/async_peek_reader.rs
+++ b/mavlink-core/src/async_peek_reader.rs
@@ -105,7 +105,7 @@ impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFE
     ///
     /// # Panics
     ///
-    /// Will always panic if `BUFFER_SIZE` is 0.  
+    /// Will panic if this `AsyncPeekReader`'s `BUFFER_SIZE` is 0.  
     pub async fn read_u8(&mut self) -> Result<u8, MessageReadError> {
         let buf = self.read_exact(1).await?;
         Ok(buf[0])

--- a/mavlink-core/src/bytes.rs
+++ b/mavlink-core/src/bytes.rs
@@ -27,6 +27,9 @@ impl<'a> Bytes<'a> {
         );
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not at least `count` bytes remain in the buffer
     #[inline]
     pub fn get_bytes(&mut self, count: usize) -> &[u8] {
         self.check_remaining(count);
@@ -36,6 +39,9 @@ impl<'a> Bytes<'a> {
         bytes
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not at least `SIZE` bytes remain in the buffer
     #[inline]
     pub fn get_array<const SIZE: usize>(&mut self) -> [u8; SIZE] {
         let bytes = self.get_bytes(SIZE);
@@ -48,6 +54,9 @@ impl<'a> Bytes<'a> {
         arr
     }
 
+    /// # Panics
+    ///
+    /// Will panic if nothing is remaining in the buffer
     #[inline]
     pub fn get_u8(&mut self) -> u8 {
         self.check_remaining(1);
@@ -57,6 +66,9 @@ impl<'a> Bytes<'a> {
         val
     }
 
+    /// # Panics
+    ///
+    /// Will panic if nothing is remaining in the buffer
     #[inline]
     pub fn get_i8(&mut self) -> i8 {
         self.check_remaining(1);
@@ -66,16 +78,25 @@ impl<'a> Bytes<'a> {
         val
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for a `u16`
     #[inline]
     pub fn get_u16_le(&mut self) -> u16 {
         u16::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for an `i16`
     #[inline]
     pub fn get_i16_le(&mut self) -> i16 {
         i16::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not at least 3 bytes ramain
     #[inline]
     pub fn get_u24_le(&mut self) -> u32 {
         const SIZE: usize = 3;
@@ -89,6 +110,9 @@ impl<'a> Bytes<'a> {
         u32::from_le_bytes(val)
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not at least 3 bytes ramain
     #[inline]
     pub fn get_i24_le(&mut self) -> i32 {
         const SIZE: usize = 3;
@@ -102,31 +126,49 @@ impl<'a> Bytes<'a> {
         i32::from_le_bytes(val)
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for a `u32`
     #[inline]
     pub fn get_u32_le(&mut self) -> u32 {
         u32::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for an `i32`
     #[inline]
     pub fn get_i32_le(&mut self) -> i32 {
         i32::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for a `u64`
     #[inline]
     pub fn get_u64_le(&mut self) -> u64 {
         u64::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for an `i64`
     #[inline]
     pub fn get_i64_le(&mut self) -> i64 {
         i64::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for a `f32`
     #[inline]
     pub fn get_f32_le(&mut self) -> f32 {
         f32::from_le_bytes(self.get_array())
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough bytes remain for a `f64`
     #[inline]
     pub fn get_f64_le(&mut self) -> f64 {
         f64::from_le_bytes(self.get_array())

--- a/mavlink-core/src/bytes.rs
+++ b/mavlink-core/src/bytes.rs
@@ -80,7 +80,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for a `u16`
+    /// Will panic if less then the 2 required bytes for a `u16` remain
     #[inline]
     pub fn get_u16_le(&mut self) -> u16 {
         u16::from_le_bytes(self.get_array())
@@ -88,7 +88,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for an `i16`
+    /// Will panic if less then the 2 required bytes for a `i16` remain
     #[inline]
     pub fn get_i16_le(&mut self) -> i16 {
         i16::from_le_bytes(self.get_array())
@@ -96,7 +96,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not at least 3 bytes ramain
+    /// Will panic if not at least 3 bytes remain
     #[inline]
     pub fn get_u24_le(&mut self) -> u32 {
         const SIZE: usize = 3;
@@ -112,7 +112,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not at least 3 bytes ramain
+    /// Will panic if not at least 3 bytes remain
     #[inline]
     pub fn get_i24_le(&mut self) -> i32 {
         const SIZE: usize = 3;
@@ -128,7 +128,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for a `u32`
+    /// Will panic if less then the 4 required bytes for a `u32` remain
     #[inline]
     pub fn get_u32_le(&mut self) -> u32 {
         u32::from_le_bytes(self.get_array())
@@ -136,7 +136,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for an `i32`
+    /// Will panic if less then the 4 required bytes for a `i32` remain
     #[inline]
     pub fn get_i32_le(&mut self) -> i32 {
         i32::from_le_bytes(self.get_array())
@@ -144,7 +144,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for a `u64`
+    /// Will panic if less then the 8 required bytes for a `u64` remain
     #[inline]
     pub fn get_u64_le(&mut self) -> u64 {
         u64::from_le_bytes(self.get_array())
@@ -152,7 +152,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for an `i64`
+    /// Will panic if less then the 8 required bytes for a `i64` remain
     #[inline]
     pub fn get_i64_le(&mut self) -> i64 {
         i64::from_le_bytes(self.get_array())
@@ -160,7 +160,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for a `f32`
+    /// Will panic if less then the 4 required bytes for a `f32` remain
     #[inline]
     pub fn get_f32_le(&mut self) -> f32 {
         f32::from_le_bytes(self.get_array())
@@ -168,7 +168,7 @@ impl<'a> Bytes<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough bytes remain for a `f64`
+    /// Will panic if less then the 8 required bytes for a `f64` remain
     #[inline]
     pub fn get_f64_le(&mut self) -> f64 {
         f64::from_le_bytes(self.get_array())

--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -69,7 +69,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store a `u16`
+    /// Will panic if less space then the 2 bytes required by a `u16` remain in the buffer
     #[inline]
     pub fn put_u16_le(&mut self, val: u16) {
         const SIZE: usize = core::mem::size_of::<u16>();
@@ -82,7 +82,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store an `i16`
+    /// Will panic if less space then the 2 bytes required by a `i16` remain in the buffer
     #[inline]
     pub fn put_i16_le(&mut self, val: i16) {
         const SIZE: usize = core::mem::size_of::<i16>();
@@ -141,7 +141,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store a `u32`
+    /// Will panic if less space then the 4 bytes required by a `u32` remain in the buffer
     #[inline]
     pub fn put_u32_le(&mut self, val: u32) {
         const SIZE: usize = core::mem::size_of::<u32>();
@@ -154,7 +154,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store an `i32`
+    /// Will panic if less space then the 4 bytes required by a `i32` remain in the buffer
     #[inline]
     pub fn put_i32_le(&mut self, val: i32) {
         const SIZE: usize = core::mem::size_of::<i32>();
@@ -167,7 +167,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store a `u64`
+    /// Will panic if less space then the 8 bytes required by a `u64` remain in the buffer
     #[inline]
     pub fn put_u64_le(&mut self, val: u64) {
         const SIZE: usize = core::mem::size_of::<u64>();
@@ -180,7 +180,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store an `i64`
+    /// Will panic if less space then the 8 bytes required by a `i64` remain in the buffer
     #[inline]
     pub fn put_i64_le(&mut self, val: i64) {
         const SIZE: usize = core::mem::size_of::<i64>();
@@ -193,7 +193,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store a `f32`
+    /// Will panic if less space then the 4 bytes required by a `f32` remain in the buffer
     #[inline]
     pub fn put_f32_le(&mut self, val: f32) {
         const SIZE: usize = core::mem::size_of::<f32>();
@@ -206,7 +206,7 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if not enough space is remaing in the buffer to store a `f64`
+    /// Will panic if less space then the 8 bytes required by a `f64` remain in the buffer
     #[inline]
     pub fn put_f64_le(&mut self, val: f64) {
         const SIZE: usize = core::mem::size_of::<f64>();

--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -32,6 +32,9 @@ impl<'a> BytesMut<'a> {
         );
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaining in the buffer to store the whole slice
     #[inline]
     pub fn put_slice(&mut self, src: &[u8]) {
         self.check_remaining(src.len());
@@ -42,6 +45,9 @@ impl<'a> BytesMut<'a> {
         self.len += src.len();
     }
 
+    /// # Panics
+    ///
+    /// Will panic if no space is remaing in the buffer
     #[inline]
     pub fn put_u8(&mut self, val: u8) {
         self.check_remaining(1);
@@ -50,6 +56,9 @@ impl<'a> BytesMut<'a> {
         self.len += 1;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if no space is remaing in the buffer
     #[inline]
     pub fn put_i8(&mut self, val: i8) {
         self.check_remaining(1);
@@ -58,6 +67,9 @@ impl<'a> BytesMut<'a> {
         self.len += 1;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store a `u16`
     #[inline]
     pub fn put_u16_le(&mut self, val: u16) {
         const SIZE: usize = core::mem::size_of::<u16>();
@@ -68,6 +80,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store an `i16`
     #[inline]
     pub fn put_i16_le(&mut self, val: i16) {
         const SIZE: usize = core::mem::size_of::<i16>();
@@ -78,6 +93,10 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if `val` is not a valid 24 bit unsigned integer or if not
+    /// enough space is remaing in the buffer to store 3 bytes
     #[inline]
     pub fn put_u24_le(&mut self, val: u32) {
         const SIZE: usize = 3;
@@ -94,6 +113,10 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if `val` is not a valid 24 bit signed integer or if not
+    /// enough space is remaing in the buffer to store 3 bytes
     #[inline]
     pub fn put_i24_le(&mut self, val: i32) {
         const SIZE: usize = 3;
@@ -116,6 +139,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store a `u32`
     #[inline]
     pub fn put_u32_le(&mut self, val: u32) {
         const SIZE: usize = core::mem::size_of::<u32>();
@@ -126,6 +152,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store an `i32`
     #[inline]
     pub fn put_i32_le(&mut self, val: i32) {
         const SIZE: usize = core::mem::size_of::<i32>();
@@ -136,6 +165,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store a `u64`
     #[inline]
     pub fn put_u64_le(&mut self, val: u64) {
         const SIZE: usize = core::mem::size_of::<u64>();
@@ -146,6 +178,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store an `i64`
     #[inline]
     pub fn put_i64_le(&mut self, val: i64) {
         const SIZE: usize = core::mem::size_of::<i64>();
@@ -156,6 +191,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store a `f32`
     #[inline]
     pub fn put_f32_le(&mut self, val: f32) {
         const SIZE: usize = core::mem::size_of::<f32>();
@@ -166,6 +204,9 @@ impl<'a> BytesMut<'a> {
         self.len += SIZE;
     }
 
+    /// # Panics
+    ///
+    /// Will panic if not enough space is remaing in the buffer to store a `f64`
     #[inline]
     pub fn put_f64_le(&mut self, val: f64) {
         const SIZE: usize = core::mem::size_of::<f64>();

--- a/mavlink-core/src/connectable.rs
+++ b/mavlink-core/src/connectable.rs
@@ -78,6 +78,12 @@ impl ConnectionAddress {
     ///  * `udpbcast:<addr>:<port>` to create a UDP broadcast
     ///  * `serial:<port>:<baudrate>` to create a serial connection
     ///  * `file:<path>` to extract file data, writing to such a connection does nothing
+    ///
+    /// # Errors
+    ///
+    /// - [`AddrNotAvailable`] if the address string could not be parsed as a valid MAVLink address
+    ///
+    /// [`AddrNotAvailable`]: io::ErrorKind::AddrNotAvailable
     pub fn parse_address(address: &str) -> Result<Self, io::Error> {
         let (protocol, address) = address.split_once(':').ok_or(io::Error::new(
             io::ErrorKind::AddrNotAvailable,

--- a/mavlink-core/src/connection/direct_serial.rs
+++ b/mavlink-core/src/connection/direct_serial.rs
@@ -13,10 +13,10 @@ use std::sync::Mutex;
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg, read_versioned_msg, write_versioned_msg};
+use crate::{read_versioned_raw_message, read_versioned_msg, write_versioned_msg};
 #[cfg(feature = "signing")]
 use crate::{
-    read_raw_versioned_msg_signed, read_versioned_msg_signed, write_versioned_msg_signed,
+    read_versioned_raw_message_signed, read_versioned_msg_signed, write_versioned_msg_signed,
     SigningConfig, SigningData,
 };
 
@@ -65,9 +65,9 @@ impl<M: Message> MavConnection<M> for SerialConnection {
         loop {
             let version = ReadVersion::from_conn_cfg::<_, M>(self);
             #[cfg(not(feature = "signing"))]
-            let result = read_raw_versioned_msg::<M, _>(port.deref_mut(), version);
+            let result = read_versioned_raw_message::<M, _>(port.deref_mut(), version);
             #[cfg(feature = "signing")]
-            let result = read_raw_versioned_msg_signed::<M, _>(
+            let result = read_versioned_raw_message_signed::<M, _>(
                 port.deref_mut(),
                 version,
                 self.signing_data.as_ref(),

--- a/mavlink-core/src/connection/direct_serial.rs
+++ b/mavlink-core/src/connection/direct_serial.rs
@@ -13,10 +13,10 @@ use std::sync::Mutex;
 use serialport::{DataBits, FlowControl, Parity, SerialPort, StopBits};
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message, read_versioned_msg, write_versioned_msg};
+use crate::{read_versioned_msg, read_versioned_raw_message, write_versioned_msg};
 #[cfg(feature = "signing")]
 use crate::{
-    read_versioned_raw_message_signed, read_versioned_msg_signed, write_versioned_msg_signed,
+    read_versioned_msg_signed, read_versioned_raw_message_signed, write_versioned_msg_signed,
     SigningConfig, SigningData,
 };
 

--- a/mavlink-core/src/connection/file.rs
+++ b/mavlink-core/src/connection/file.rs
@@ -12,9 +12,11 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_versioned_raw_message, read_versioned_msg};
+use crate::{read_versioned_msg, read_versioned_raw_message};
 #[cfg(feature = "signing")]
-use crate::{read_versioned_raw_message_signed, read_versioned_msg_signed, SigningConfig, SigningData};
+use crate::{
+    read_versioned_msg_signed, read_versioned_raw_message_signed, SigningConfig, SigningData,
+};
 
 pub mod config;
 

--- a/mavlink-core/src/connection/file.rs
+++ b/mavlink-core/src/connection/file.rs
@@ -12,9 +12,9 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 #[cfg(not(feature = "signing"))]
-use crate::{read_raw_versioned_msg, read_versioned_msg};
+use crate::{read_versioned_raw_message, read_versioned_msg};
 #[cfg(feature = "signing")]
-use crate::{read_raw_versioned_msg_signed, read_versioned_msg_signed, SigningConfig, SigningData};
+use crate::{read_versioned_raw_message_signed, read_versioned_msg_signed, SigningConfig, SigningData};
 
 pub mod config;
 
@@ -71,9 +71,9 @@ impl<M: Message> MavConnection<M> for FileConnection {
         loop {
             let version = ReadVersion::from_conn_cfg::<_, M>(self);
             #[cfg(not(feature = "signing"))]
-            let result = read_raw_versioned_msg::<M, _>(file.deref_mut(), version);
+            let result = read_versioned_raw_message::<M, _>(file.deref_mut(), version);
             #[cfg(feature = "signing")]
-            let result = read_raw_versioned_msg_signed::<M, _>(
+            let result = read_versioned_raw_message_signed::<M, _>(
                 file.deref_mut(),
                 version,
                 self.signing_data.as_ref(),

--- a/mavlink-core/src/connection/tcp.rs
+++ b/mavlink-core/src/connection/tcp.rs
@@ -4,9 +4,9 @@ use crate::connection::get_socket_addr;
 use crate::connection::MavConnection;
 use crate::peek_reader::PeekReader;
 #[cfg(not(feature = "signing"))]
-use crate::read_raw_versioned_msg;
+use crate::read_versioned_raw_message;
 #[cfg(feature = "signing")]
-use crate::read_raw_versioned_msg_signed;
+use crate::read_versioned_raw_message_signed;
 use crate::Connectable;
 use crate::MAVLinkMessageRaw;
 use crate::{MavHeader, MavlinkVersion, Message, ReadVersion};
@@ -108,9 +108,9 @@ impl<M: Message> MavConnection<M> for TcpConnection {
         let mut reader = self.reader.lock().unwrap();
         let version = ReadVersion::from_conn_cfg::<_, M>(self);
         #[cfg(not(feature = "signing"))]
-        let result = read_raw_versioned_msg::<M, _>(reader.deref_mut(), version);
+        let result = read_versioned_raw_message::<M, _>(reader.deref_mut(), version);
         #[cfg(feature = "signing")]
-        let result = read_raw_versioned_msg_signed::<M, _>(
+        let result = read_versioned_raw_message_signed::<M, _>(
             reader.deref_mut(),
             version,
             self.signing_data.as_ref(),

--- a/mavlink-core/src/connection/udp.rs
+++ b/mavlink-core/src/connection/udp.rs
@@ -4,9 +4,9 @@ use crate::connection::get_socket_addr;
 use crate::connection::MavConnection;
 use crate::peek_reader::PeekReader;
 #[cfg(not(feature = "signing"))]
-use crate::read_raw_versioned_msg;
+use crate::read_versioned_raw_message;
 #[cfg(feature = "signing")]
-use crate::read_raw_versioned_msg_signed;
+use crate::read_versioned_raw_message_signed;
 use crate::Connectable;
 use crate::MAVLinkMessageRaw;
 use crate::{MavHeader, MavlinkVersion, Message, ReadVersion};
@@ -115,9 +115,9 @@ impl<M: Message> MavConnection<M> for UdpConnection {
         loop {
             let version = ReadVersion::from_conn_cfg::<_, M>(self);
             #[cfg(not(feature = "signing"))]
-            let result = read_raw_versioned_msg::<M, _>(reader.deref_mut(), version);
+            let result = read_versioned_raw_message::<M, _>(reader.deref_mut(), version);
             #[cfg(feature = "signing")]
-            let result = read_raw_versioned_msg_signed::<M, _>(
+            let result = read_versioned_raw_message_signed::<M, _>(
                 reader.deref_mut(),
                 version,
                 self.signing_data.as_ref(),

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -365,7 +365,7 @@ pub fn read_versioned_msg<M: Message, R: Read>(
 }
 
 /// Read and parse a MAVLink message of the specified version from a [`PeekReader`].
-pub fn read_raw_versioned_msg<M: Message, R: Read>(
+pub fn read_versioned_raw_message<M: Message, R: Read>(
     r: &mut PeekReader<R>,
     version: ReadVersion,
 ) -> Result<MAVLinkMessageRaw, error::MessageReadError> {
@@ -395,7 +395,7 @@ pub async fn read_versioned_msg_async<M: Message, R: tokio::io::AsyncRead + Unpi
 
 /// Asynchronously read and parse a MAVLinkMessageRaw of the specified version from a [`AsyncPeekReader`].
 #[cfg(feature = "tokio-1")]
-pub async fn read_raw_versioned_msg_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
+pub async fn read_versioned_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     r: &mut AsyncPeekReader<R>,
     version: ReadVersion,
 ) -> Result<MAVLinkMessageRaw, error::MessageReadError> {
@@ -415,7 +415,7 @@ pub async fn read_raw_versioned_msg_async<M: Message, R: tokio::io::AsyncRead + 
 /// When using [`ReadVersion::Single`]`(`[`MavlinkVersion::V1`]`)` signing is ignored.
 /// When using [`ReadVersion::Any`] MAVlink 1 messages are treated as unsigned.
 #[cfg(feature = "signing")]
-pub fn read_raw_versioned_msg_signed<M: Message, R: Read>(
+pub fn read_versioned_raw_message_signed<M: Message, R: Read>(
     r: &mut PeekReader<R>,
     version: ReadVersion,
     signing_data: Option<&SigningData>,
@@ -453,7 +453,7 @@ pub fn read_versioned_msg_signed<M: Message, R: Read>(
 /// When using [`ReadVersion::Single`]`(`[`MavlinkVersion::V1`]`)` signing is ignored.
 /// When using [`ReadVersion::Any`] MAVlink 1 messages are treated as unsigned.
 #[cfg(all(feature = "tokio-1", feature = "signing"))]
-pub async fn read_raw_versioned_msg_async_signed<M: Message, R: tokio::io::AsyncRead + Unpin>(
+pub async fn read_versioned_raw_message_async_signed<M: Message, R: tokio::io::AsyncRead + Unpin>(
     r: &mut AsyncPeekReader<R>,
     version: ReadVersion,
     signing_data: Option<&SigningData>,

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -453,7 +453,10 @@ pub fn read_versioned_msg_signed<M: Message, R: Read>(
 /// When using [`ReadVersion::Single`]`(`[`MavlinkVersion::V1`]`)` signing is ignored.
 /// When using [`ReadVersion::Any`] MAVlink 1 messages are treated as unsigned.
 #[cfg(all(feature = "tokio-1", feature = "signing"))]
-pub async fn read_versioned_raw_message_async_signed<M: Message, R: tokio::io::AsyncRead + Unpin>(
+pub async fn read_versioned_raw_message_async_signed<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
     r: &mut AsyncPeekReader<R>,
     version: ReadVersion,
     signing_data: Option<&SigningData>,

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -108,7 +108,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     ///
     /// # Panics
     ///
-    /// Will always panic if `BUFFER_SIZE` is 0.  
+    /// Will panic if this `PeekReader`'s `BUFFER_SIZE` is 0.  
     pub fn read_u8(&mut self) -> Result<u8, MessageReadError> {
         let buf = self.read_exact(1)?;
         Ok(buf[0])

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -24,7 +24,7 @@ use crate::error::MessageReadError;
 
 /// A buffered/peekable reader
 ///
-/// This reader wraps a type implementing [`std::io::Read`] and adds buffering via an internal buffer.
+/// This reader wraps a type implementing [`Read`] and adds buffering via an internal buffer.
 ///
 /// It allows the user to `peek` a specified number of bytes (without consuming them),
 /// to `read` bytes (consuming them), or to `consume` them after `peek`ing.
@@ -44,7 +44,7 @@ pub struct PeekReader<R, const BUFFER_SIZE: usize = 280> {
 }
 
 impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
-    /// Instantiates a new [`PeekReader`], wrapping the provided [`std::io::Read`]er and using the default chunk size
+    /// Instantiates a new [`PeekReader`], wrapping the provided [`Read`]er and using the default chunk size
     pub fn new(reader: R) -> Self {
         Self {
             buffer: [0; BUFFER_SIZE],
@@ -57,7 +57,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// Peeks an exact amount of bytes from the internal buffer
     ///
     /// If the internal buffer does not contain enough data, this function will read
-    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
     /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
     ///
@@ -72,7 +72,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// Reads a specified amount of bytes from the internal buffer
     ///
     /// If the internal buffer does not contain enough data, this function will read
-    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
     /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
     ///
@@ -85,7 +85,7 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// Reads a byte from the internal buffer
     ///
     /// If the internal buffer does not contain enough data, this function will read
-    /// from the underlying [`std::io::Read`]er until it does, an error occurs or no more data can be read (EOF).
+    /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
     /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
     ///
@@ -106,14 +106,14 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
         amount
     }
 
-    /// Returns an immutable reference to the underlying [`std::io::Read`]er
+    /// Returns an immutable reference to the underlying [`Read`]er
     ///
     /// Reading directly from the underlying reader will cause data loss
     pub fn reader_ref(&self) -> &R {
         &self.reader
     }
 
-    /// Returns a mutable reference to the underlying [`std::io::Read`]er
+    /// Returns a mutable reference to the underlying [`Read`]er
     ///
     /// Reading directly from the underlying reader will cause data loss
     pub fn reader_mut(&mut self) -> &mut R {

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -59,11 +59,17 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function does not consume data from the buffer, so subsequent calls to `peek` or `read` functions
     /// will still return the peeked data.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`Read`]er it is returned
+    /// - If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic when attempting to read more bytes then `BUFFER_SIZE`
     pub fn peek_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
         let result = self.fetch(amount, false);
         result
@@ -74,10 +80,16 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`Read`]er it is returned
+    /// - If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic when attempting to read more bytes then `BUFFER_SIZE`
     pub fn read_exact(&mut self, amount: usize) -> Result<&[u8], MessageReadError> {
         self.fetch(amount, true)
     }
@@ -87,10 +99,16 @@ impl<R: Read, const BUFFER_SIZE: usize> PeekReader<R, BUFFER_SIZE> {
     /// If the internal buffer does not contain enough data, this function will read
     /// from the underlying [`Read`]er until it does, an error occurs or no more data can be read (EOF).
     ///
-    /// If an EOF occurs and the specified amount could not be read, this function will return an [`ErrorKind::UnexpectedEof`].
-    ///
     /// This function consumes the data from the buffer, unless an error occurs, in which case no data is consumed.
     ///
+    /// # Errors
+    ///
+    /// - If any error occurs while reading from the underlying [`Read`]er it is returned
+    /// - If an EOF occurs before a byte could be read, this function will return an [`ErrorKind::UnexpectedEof`].
+    ///
+    /// # Panics
+    ///
+    /// Will always panic if `BUFFER_SIZE` is 0.  
     pub fn read_u8(&mut self) -> Result<u8, MessageReadError> {
         let buf = self.read_exact(1)?;
         Ok(buf[0])

--- a/mavlink-core/src/signing.rs
+++ b/mavlink-core/src/signing.rs
@@ -75,14 +75,14 @@ impl SigningData {
     ///
     /// This respects the `allow_unsigned` parameter in [`SigningConfig`].
     pub fn verify_signature(&self, message: &MAVLinkV2MessageRaw) -> bool {
-        // The code that holds the mutex lock is not expected to panic, therefore the expect is justified.
-        // The only issue that might cause a panic, presuming the opertions on the message buffer are sound,
-        // is the `SystemTime::now()` call in `get_current_timestamp()`.
-        let mut state = self
-            .state
-            .lock()
-            .expect("Code holding MutexGuard should not panic.");
         if message.incompatibility_flags() & MAVLINK_IFLAG_SIGNED > 0 {
+            // The code that holds the mutex lock is not expected to panic, therefore the expect is justified.
+            // The only issue that might cause a panic, presuming the opertions on the message buffer are sound,
+            // is the `SystemTime::now()` call in `get_current_timestamp()`.
+            let mut state = self
+                .state
+                .lock()
+                .expect("Code holding MutexGuard should not panic.");
             state.timestamp = u64::max(state.timestamp, Self::get_current_timestamp());
             let timestamp = message.signature_timestamp();
             let src_system = message.system_id();


### PR DESCRIPTION
This PR adds better error and documentation to `mavlink-core`

# Breaking

To have consistent `read_` function names I renamed the following group of functions:
`read_raw_versioned_msg[_async][_signed]` -> `read_versioned_raw_message[_async][_signed]`

# Changes

- `# Errors` and `# Panics` doc sections to all applicable public functions in `mavlink-core`
- Add unified doc for `read_` and `write_` functions and their errors in mavlink-core/src/lib.rs
- simplyfy doc link when applicable
- properly import commonly used items e.g. `crate::error::MessageReadError`

# Lints

There are 2 clippy lints that check for the existence of these sections but in my experience the one for panics is not very useful since it has many false positives and negatives. Therefore I did not enable them.

# Other

Only lock signing mutex when message actually needs to be signed, this is a minor performance improvement for the `signing` feature. This is so minor that I didn't want to put it in a separate PR.