### PR TITLE
Enable formatting of generated code by default

### DIFF
--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -40,7 +40,7 @@ rand = { version = "0.9", optional = true, default-features = false, features = 
 ts-rs = { version = "11.0.1", optional = true }
 
 [features]
-default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega", "common"]
+default = ["std", "tcp", "udp", "direct-serial", "serde", "ardupilotmega", "common", "format-generated-code"]
 
 all = []
 ardupilotmega = []


### PR DESCRIPTION
This is a proposal to enable the code formatting of the generated code by default. There are two reasons for why I think we should do this:

1. Some editors, including vscode do not like files with very-very long lines. When I'm ctrl-clicking through types with rust-analyzer to find where they are defined and how the generated code looks like and land in the generated code of rust-mavlink it often makes vscode sluggish and unable to provide syntax highlighting sometimes resulting in a hang. When formatting the code, everything works as expected.
2. When running `cargo test` on rust-mavlink, if there is an issue with the generated code then the tests will spit out the whole generated file instead of only the relevant line(s). This makes it very inconvenient to run the tests. You can of course work around this but it provides with a bad first experience for contributors that are unaware and run `cargo test` for their changes.

Those are the reasons why I think this would be a better default. But of course there might be reasons not to do this that I'm unaware of. I would be interested to hear if there are any such reasons. 