### PR TITLE
post-release: bump the old mavlink version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ with bindings for all message sets.
 Add to your Cargo.toml:
 
 ```
-mavlink = "0.15"
+mavlink = "0.16"
 ```
 
 Building this crate requires `git`.


### PR DESCRIPTION
0.15 is not the latest version anymore.