### PR TITLE
fix(427): arbitrary handles utf-8 bytes with truncation

### DIFF
--- a/mavlink-core/src/types.rs
+++ b/mavlink-core/src/types.rs
@@ -137,7 +137,12 @@ impl<'de, const N: usize> Deserialize<'de> for CharArray<N> {
 impl<'a, const N: usize> Arbitrary<'a> for CharArray<N> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let mut data = [0u8; N];
-        u.fill_buffer(&mut data)?;
+
+        for b in &mut data {
+            // Take a char from the printable ASCII range.
+            *b = u.int_in_range(32..=126)?;
+        }
+
         Ok(CharArray::new(data))
     }
 }


### PR DESCRIPTION
# Fix #427: Arbitrary handles UTF-8 bytes with truncation

## Summary

Fixes the `Arbitrary` implementation for `CharArray<N>` to properly handle UTF-8 encoded strings instead of filling with random bytes. This was inspired from the disccusion [here](https://github.com/mavlink/rust-mavlink/issues/427#issuecomment-3498246724), attempting to solve #427 .

## Problem

The previous implementation used `u.fill_buffer(&mut data)` which filled the array with arbitrary bytes. This could produce invalid UTF-8 sequences, causing issues when the `CharArray` was expected to contain valid string data.

## Solution

- Generate only u8's from the readable ascii characters

This ensures that fuzz testing with the `arbitrary` feature produces valid UTF-8 content that won't cause unexpected behavior.

## Changes

- `mavlink-core/src/types.rs`: Updated `Arbitrary` impl for `CharArray<N>` with UTF-8 aware truncation
