### PR TITLE
chore(ci): simplify MSRV check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-hack
-      - run: cargo hack --no-dev-deps --rust-vresion check --package mavlink ${{ matrix.features }}
+      - run: cargo hack --no-dev-deps --rust-version check --package mavlink ${{ matrix.features }}
 
   build:
     needs: [formatting, linting, internal-tests, mavlink-dump, msrv]


### PR DESCRIPTION
simplify the MSRV and check only the root library (since downstream users are not exposed to the MSRV otherwise)