### PR TITLE
refactor: remove i24 reading/writing

### DIFF
--- a/mavlink-core/src/bytes.rs
+++ b/mavlink-core/src/bytes.rs
@@ -140,25 +140,6 @@ impl<'a> Bytes<'a> {
 
     /// # Errors
     ///
-    /// Will return an error if not at least 3 bytes remain
-    #[inline]
-    pub fn get_i24_le(&mut self) -> Result<i32, Error> {
-        const SIZE: usize = 3;
-
-        let mut val = [0u8; SIZE + 1];
-        val[..3].copy_from_slice(
-            self.data
-                .get(self.pos..self.pos + SIZE)
-                .ok_or_else(|| Error::not_enough_buffer(SIZE, self))?,
-        );
-        self.pos += SIZE;
-
-        debug_assert_eq!(val[3], 0);
-        Ok(i32::from_le_bytes(val))
-    }
-
-    /// # Errors
-    ///
     /// Will return an error if less then the 4 required bytes for a `u32` remain
     #[inline]
     pub fn get_u32_le(&mut self) -> Result<u32, Error> {

--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -115,32 +115,6 @@ impl<'a> BytesMut<'a> {
 
     /// # Panics
     ///
-    /// Will panic if `val` is not a valid 24 bit signed integer or if not
-    /// enough space is remaing in the buffer to store 3 bytes
-    #[inline]
-    pub fn put_i24_le(&mut self, val: i32) {
-        const SIZE: usize = 3;
-        const MIN: i32 = 2i32.pow(23);
-        const MAX: i32 = 2i32.pow(23) - 1;
-
-        assert!(
-            val <= MAX,
-            "Attempted to put value that is too large for 24 bits, \
-	     attempted to push: {val}, max allowed: {MAX}",
-        );
-        assert!(
-            val >= MIN,
-            "Attempted to put value that is too negative for 24 bits, \
-	     attempted to push: {val}, min allowed: {MIN}",
-        );
-
-        let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..3]);
-        self.len += SIZE;
-    }
-
-    /// # Panics
-    ///
     /// Will panic if less space then the 4 bytes required by a `u32` remain in the buffer
     #[inline]
     pub fn put_u32_le(&mut self, val: u32) {


### PR DESCRIPTION
Removes i24 reading/writing.

This implementation is buggy and unused. See #448 for more context.