### PR TITLE
improve PeekReader and AsyncPeekReader

### DIFF
--- a/mavlink-core/src/async_peek_reader.rs
+++ b/mavlink-core/src/async_peek_reader.rs
@@ -167,3 +167,24 @@ impl<R: AsyncReadExt + Unpin, const BUFFER_SIZE: usize> AsyncPeekReader<R, BUFFE
         Ok(result)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion failed")]
+    async fn test_peek_exact_panics_when_amount_exceeds_buffer_size() {
+        let data = b"abcd";
+        let mut reader = AsyncPeekReader::<_, 4>::new(&data[..]);
+        let _ = reader.peek_exact(5).await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion failed")]
+    async fn test_read_exact_panics_when_amount_exceeds_buffer_size() {
+        let data = b"abcd";
+        let mut reader = AsyncPeekReader::<_, 4>::new(&data[..]);
+        let _ = reader.read_exact(5).await;
+    }
+}

--- a/mavlink-core/src/peek_reader.rs
+++ b/mavlink-core/src/peek_reader.rs
@@ -221,4 +221,20 @@ mod tests {
             _ => panic!("Expected Io error with UnexpectedEof"),
         }
     }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_peek_exact_panics_when_amount_exceeds_buffer_size() {
+        let data = b"abcd";
+        let mut reader = PeekReader::<_, 4>::new(&data[..]);
+        let _ = reader.peek_exact(5);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn test_read_exact_panics_when_amount_exceeds_buffer_size() {
+        let data = b"abcd";
+        let mut reader = PeekReader::<_, 4>::new(&data[..]);
+        let _ = reader.read_exact(5);
+    }
 }


### PR DESCRIPTION
The first commit improves `AsyncPeekReader::fetch` by removing the need of intermediate stack buffer. Instead of reading into a stack buffer then copying it, we now read directly into the internal buffer.

The cecond commit moves `PeekReader::fetch` assertion outside the loop.

The final commit adds test coverage for the buffer size assertions we have in `AsyncPeekReader::fetch` and `PeekReader::fetch`.