### PR TITLE
document the project in more detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,144 @@
 # rust-mavlink
 
-[![Build status](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml/badge.svg)](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml)
 [![Crate info](https://img.shields.io/crates/v/mavlink.svg)](https://crates.io/crates/mavlink)
+[![Crate downloads](https://img.shields.io/crates/d/mavlink.svg)](https://crates.io/crates/mavlink)
+[![Rust 1.80+](https://img.shields.io/badge/rust-1.80%2B-blue.svg)](https://github.com/mavlink/rust-mavlink/blob/master/Cargo.toml)
+[![License](https://img.shields.io/crates/l/mavlink.svg)](https://github.com/mavlink/rust-mavlink#license)
+[![Build status](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml/badge.svg)](https://github.com/mavlink/rust-mavlink/actions/workflows/test.yml)
 [![Documentation](https://docs.rs/mavlink/badge.svg)](https://docs.rs/mavlink)
 
-Rust implementation of the [MAVLink](https://mavlink.io/en) UAV messaging protocol,
-with bindings for all message sets.
+Pure Rust implementation of the [MAVLink](https://mavlink.io/en) UAV messaging protocol.
+Provides strongly typed message bindings, frame encode/decode and connection APIs for serial,
+UDP, TCP, file connection protocols with a rich set of features.
 
-Add to your Cargo.toml:
+## What rust-mavlink provides
 
+- Rust bindings for MAVLink dialects
+- Read/write support for MAVLink v1 and v2
+- TCP, UDP, Serial and File connection support. 
+- Signing support.
+- Blocking and async support.
+- std and embedded support.
+- Codegen tool mavlink-bindgen for creating Rust bindings from MAVLink XML dialect definitions.
+
+## Workspace crates
+
+| Crate | Purpose |
+| --- | --- |
+| [`mavlink`](https://crates.io/crates/mavlink) | Main crate with generated dialect modules and high-level APIs |
+| [`mavlink-core`](https://crates.io/crates/mavlink-core) | Core protocol types, parser/serializer, and connection traits |
+| [`mavlink-bindgen`](https://crates.io/crates/mavlink-bindgen) | XML-to-Rust code generator used by `mavlink` |
+
+## Build requirements
+
+Building the `mavlink` crate runs a build script that initializes
+the bundled MAVLink definition submodule, so `git` must be available.
+
+## Quick start
+
+Add the crate:
+
+```toml
+[dependencies]
+mavlink = "0.17.1"
 ```
-mavlink = "0.16"
+
+Simple code example:
+
+```rust
+use mavlink::{dialects::ardupilotmega, MavConnection};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let conn = mavlink::connect::<ardupilotmega::MavMessage>("udpin:0.0.0.0:14550")?;
+
+    let heartbeat = ardupilotmega::MavMessage::HEARTBEAT(ardupilotmega::HEARTBEAT_DATA {
+        custom_mode: 0,
+        mavtype: ardupilotmega::MavType::MAV_TYPE_QUADROTOR,
+        autopilot: ardupilotmega::MavAutopilot::MAV_AUTOPILOT_ARDUPILOTMEGA,
+        base_mode: ardupilotmega::MavModeFlag::empty(),
+        system_status: ardupilotmega::MavState::MAV_STATE_STANDBY,
+        mavlink_version: 3,
+    });
+
+    conn.send(&mavlink::MavHeader::default(), &heartbeat)?;
+    let (header, message) = conn.recv()?;
+
+    println!(
+        "received from sys={}, comp={}: {message:?}",
+        header.system_id, header.component_id
+    );
+
+    Ok(())
+}
 ```
 
-Building this crate requires `git`.
+## Supported address formats
+
+- `tcpin:<addr>:<port>`: TCP server
+- `tcpout:<addr>:<port>`: TCP client
+- `udpin:<addr>:<port>`: UDP listener
+- `udpout:<addr>:<port>`: UDP sender
+- `udpbcast:<addr>:<port>`: UDP broadcast sender
+- `serial:<port>:<baudrate>`: serial port connection
+- `file:<path>`: read MAVLink frames from a file
+
+## Feature flags
+
+Transport and runtime:
+
+- `embedded`
+- `std`
+- `tokio`
+- `transport-direct-serial`
+- `transport-tcp`
+- `transport-udp`
+
+Protocol and code generation:
+
+- `arbitrary`
+- `format-generated-code`
+- `mav2-message-extensions`
+- `mav2-message-signing`
+- `serde`
+- `ts-rs`
+
+Dialects:
+
+- `dialect-all`
+- `dialect-ardupilotmega`
+- `dialect-asluav`
+- `dialect-avssuas`
+- `dialect-common`
+- `dialect-csairlink`
+- `dialect-cubepilot`
+- `dialect-development`
+- `dialect-icarous`
+- `dialect-loweheiser`
+- `dialect-marsh`
+- `dialect-matrixpilot`
+- `dialect-minimal`
+- `dialect-paparazzi`
+- `dialect-python_array_test`
+- `dialect-standard`
+- `dialect-stemstudios`
+- `dialect-storm32`
+- `dialect-test`
+- `dialect-ualberta`
+- `dialect-uavionix`
+
+Note that `std` and `embedded` features are mutually exclusive.
 
 ## Examples
-See [examples/](mavlink/examples/mavlink-dump/src/main.rs) for different usage examples.
 
-### mavlink-dump
-[examples/mavlink-dump](mavlink/examples/mavlink-dump/src/main.rs) contains an executable example that can be used to test message reception.
-
-It can be executed directly by running:
-```
-cargo run --example mavlink-dump [options]
-```
-
-It's also possible to install the working example via `cargo` command line:
-```sh
-cargo install --path examples/mavlink-dump
-```
-
-It can then be executed by running:
-```
-mavlink-dump [options]
-```
-
-Execution call example:
-```sh
-mavlink-dump udpin:127.0.0.1:14540
-```
-
-### Community projects
-Check some projects built by the community:
-- [mavlink2rest](https://github.com/patrickelectric/mavlink2rest): A REST server that provides easy and friendly access to mavlink messages.
-- [mavlink-camera-manager](https://github.com/mavlink/mavlink-camera-manager): Extensible cross-platform camera server.
+See [`mavlink/examples/`](mavlink/examples/) for runnable examples.
 
 ## Maintainers
-See [MAINTAINERS.md](MAINTAINERS.md) for active maintainers, release managers and their contact details.
+
+See [MAINTAINERS.md](MAINTAINERS.md) for active maintainers, release managers and contact details.
 
 ## License
 
-Licensed under either of
- * Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
-at your option.
+Licensed under either of:
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT) at your option.

--- a/mavlink/examples/README.md
+++ b/mavlink/examples/README.md
@@ -1,0 +1,33 @@
+# Examples
+
+This directory contains runnable examples for different targets.
+
+## Available examples
+
+- [`mavlink-dump`](mavlink-dump/src/main.rs): desktop example for receiving and printing MAVLink frames.
+- [`embedded`](embedded): blocking embedded example.
+- [`embedded-async-read`](embedded-async-read): async embedded read loop example.
+
+## Running `mavlink-dump`
+
+From the workspace root:
+
+```bash
+cargo run --example mavlink-dump -- udpin:127.0.0.1:14540
+```
+
+The first argument is a MAVLink connection string such as:
+
+- `udpin:0.0.0.0:14550`
+- `udpout:127.0.0.1:14550`
+- `tcpin:0.0.0.0:5760`
+- `tcpout:127.0.0.1:5760`
+- `serial:/dev/ttyUSB0:115200`
+- `file:./mavlink/tests/log.tlog`
+
+## Running embedded examples
+
+See the per-example docs:
+
+- [`embedded/README.md`](embedded/README.md)
+- [`embedded-async-read/README.md`](embedded-async-read/README.md)

--- a/mavlink/examples/embedded-async-read/README.md
+++ b/mavlink/examples/embedded-async-read/README.md
@@ -1,4 +1,5 @@
 # rust-MAVLink Embedded async example (with reading loop)
+
 ### How to run:
 - Install cargo flash:
   - cargo install cargo-flash

--- a/mavlink/examples/embedded/README.md
+++ b/mavlink/examples/embedded/README.md
@@ -1,4 +1,5 @@
 # rust-MAVLink Embedded example
+
 ### How to run:
 - Install cargo flash:
   - cargo install cargo-flash


### PR DESCRIPTION
Updates project documentation to be clearer and up to date.

- Reworked README.md to better reflect current project capabilities.
- Removed stale community-project references (there are many more community projects exists today and I believe we cannot track of them).
- Added new badges at the top of the README.md.
- Simplified examples section to point to mavlink/examples.
- Listed all supported dialect feature flags explicitly.


Docs-only change, no code behavior changes.