### PR TITLE
Avoid oversized payload parsing buffer allocation when not required

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -973,9 +973,10 @@ impl MavMessage {
             quote! {
                 let avail_len = __input.len();
 
-                let mut payload_buf  = [0; Self::ENCODED_LEN];
+                let mut payload_buf;
                 let mut buf = if avail_len < Self::ENCODED_LEN {
                     //copy available bytes into an oversized buffer filled with zeros
+                    payload_buf = [0; Self::ENCODED_LEN];
                     payload_buf[0..avail_len].copy_from_slice(__input);
                     Bytes::new(&payload_buf)
                 } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
@@ -117,8 +117,9 @@ impl MessageData for PING_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
@@ -81,8 +81,9 @@ impl MessageData for HEARTBEAT_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
@@ -81,8 +81,9 @@ impl MessageData for BOOL_TEST_MESSAGE_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
@@ -67,8 +67,9 @@ impl MessageData for CUBEPILOT_RAW_RC_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -107,8 +107,9 @@ impl MessageData for PARAM_REQUEST_LIST_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {
@@ -192,8 +193,9 @@ impl MessageData for PARAM_REQUEST_READ_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {
@@ -290,8 +292,9 @@ impl MessageData for PARAM_SET_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {
@@ -395,8 +398,9 @@ impl MessageData for PARAM_VALUE_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
@@ -152,8 +152,9 @@ impl MessageData for SMART_BATTERY_INFO_DATA {
         __input: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         let avail_len = __input.len();
-        let mut payload_buf = [0; Self::ENCODED_LEN];
+        let mut payload_buf;
         let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
             payload_buf[0..avail_len].copy_from_slice(__input);
             Bytes::new(&payload_buf)
         } else {


### PR DESCRIPTION
performance difference is ~5%
tested on arbitrary messages from with ids 0-255 (if they exist)
```
before:
mavlink v1:       1,983.18 ns/iter (+/- 31.22)
mavlink v2:       1,994.77 ns/iter (+/- 83.17)
after:
mavlink v1:       1,893.43 ns/iter (+/- 186.79)
mavlink v2:       1,903.78 ns/iter (+/- 89.57)
```
test code:
```rs
bencher.iter(|| {
    for (id, buf) in &msg_bufs {
        std::hint::black_box(MavMessage::parse(version, *id, buf)).unwrap();
    }
})
```