### PR TITLE
refactor(bytes_mut): replace unsafe copy with safe copy_from_slice

### DIFF
--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -39,7 +39,7 @@ impl<'a> BytesMut<'a> {
     pub fn put_slice(&mut self, src: &[u8]) {
         self.check_remaining(src.len());
 
-        self.data[self.len..self.len + src.len()].copy_from_slice(src);
+        self.data[self.len..(self.len + src.len())].copy_from_slice(src);
         self.len += src.len();
     }
 
@@ -74,7 +74,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -87,7 +87,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -107,7 +107,7 @@ impl<'a> BytesMut<'a> {
         );
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..3]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..3]);
         self.len += SIZE;
     }
 
@@ -120,7 +120,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -133,7 +133,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -146,7 +146,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -159,7 +159,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -172,7 +172,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 
@@ -185,7 +185,7 @@ impl<'a> BytesMut<'a> {
         self.check_remaining(SIZE);
 
         let src = val.to_le_bytes();
-        self.data[self.len..self.len + SIZE].copy_from_slice(&src[..]);
+        self.data[self.len..(self.len + SIZE)].copy_from_slice(&src[..]);
         self.len += SIZE;
     }
 }

--- a/mavlink-core/src/bytes_mut.rs
+++ b/mavlink-core/src/bytes_mut.rs
@@ -39,9 +39,7 @@ impl<'a> BytesMut<'a> {
     pub fn put_slice(&mut self, src: &[u8]) {
         self.check_remaining(src.len());
 
-        unsafe {
-            core::ptr::copy_nonoverlapping(src.as_ptr(), &mut self.data[self.len], src.len());
-        }
+        self.data[self.len..self.len + src.len()].copy_from_slice(src);
         self.len += src.len();
     }
 


### PR DESCRIPTION
Use `copy_from_slice` in `BytesMut::put_slice` instead of manually calling `copy_nonoverlapping`. The existing bounds check already ensures the destination range is valid, so the safe slice API is equivalent and removes unnecessary unsafe code.