### PR TITLE
adjust bitflag size check, add SerializationError

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -86,16 +86,19 @@ impl MavProfile {
                             enm.primitive = Some(field.mavtype.rust_primitive_type());
 
                             // check if all enum values can be stored in the fields
+                            let mut any_fit = false;
                             for entry in &enm.entries {
-                                assert!(
-                                    entry.value.unwrap_or_default()
-                                        <= field.mavtype.max_int_value(),
-                                    "bitflag enum field {} of {} must be able to fit all possible values for {}",
-                                    field.name,
-                                    msg.name,
-                                    enum_name,
-                                );
+                                if field.mavtype.max_int_value() < entry.value.unwrap_or_default() {
+                                    field.is_undersized = true;
+                                } else {
+                                    any_fit = true;
+                                }
                             }
+                            assert!(
+                                any_fit,
+                                "bitflag enum field {} of {} must be able to fit at least one possible value {}",
+                                field.name, msg.name, enum_name,
+                            );
 
                             // Fix fields in backwards manner
                             if field.display.is_none() {
@@ -435,7 +438,7 @@ impl MavProfile {
     #[inline(always)]
     fn emit_mav_message_serialize(&self, enums: &Vec<TokenStream>) -> TokenStream {
         quote! {
-            fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+            fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> Result<usize, ::mavlink_core::error::SerializationError> {
                 match self {
                     #(Self::#enums(body) => body.ser(version, bytes),)*
                 }
@@ -918,20 +921,19 @@ impl MavMessage {
             let mut __tmp = BytesMut::new(bytes);
 
             if __tmp.remaining() < Self::ENCODED_LEN {
-                panic!(
-                    "buffer is too small (need {} bytes, but got {})",
-                    Self::ENCODED_LEN,
-                    __tmp.remaining(),
-                )
+                return Err(::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                })
             }
 
             #(#ser_vars)*
             if matches!(version, MavlinkVersion::V2) {
                 #(#ser_ext_vars)*
                 let len = __tmp.len();
-                ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+                Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
             } else {
-                __tmp.len()
+                Ok(__tmp.len())
             }
         }
     }
@@ -1060,7 +1062,7 @@ impl MavMessage {
                     #deser_vars
                 }
 
-                fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+                fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> Result<usize, ::mavlink_core::error::SerializationError> {
                     #serialize_vars
                 }
             }
@@ -1107,6 +1109,7 @@ pub struct MavField {
     pub enumtype: Option<String>,
     pub display: Option<String>,
     pub is_extension: bool,
+    pub is_undersized: bool,
 }
 
 impl MavField {
@@ -1142,6 +1145,9 @@ impl MavField {
             let desc = URL_REGEX.replace_all(val, "<$1>");
             ts.extend(quote!(#[doc = #desc]));
         }
+        if self.is_undersized {
+            ts.extend(quote!(#[doc = "This field can not store all possible bitflag values and can cause a serialization error at runtime."]));
+        }
         ts
     }
 
@@ -1164,8 +1170,12 @@ impl MavField {
                     // potentially a bitflag
                     if dsp == "bitmask" {
                         // it is a bitflag
-                        name += ".bits() as ";
-                        name += &self.mavtype.rust_type();
+                        if self.is_undersized {
+                            name += ".bits().try_into()? ";
+                        } else {
+                            name += ".bits() as ";
+                            name += &self.mavtype.rust_type();
+                        }
                     } else {
                         panic!("Display option not implemented");
                     }
@@ -2301,6 +2311,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2309,6 +2320,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2325,6 +2337,7 @@ mod tests {
                 enumtype: None,
                 display: None,
                 is_extension: false,
+                is_undersized: false,
             }],
             deprecated: None,
         };
@@ -2363,6 +2376,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt16,
@@ -2371,6 +2385,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2394,6 +2409,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2402,6 +2418,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2424,6 +2441,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2432,6 +2450,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2452,6 +2471,7 @@ mod tests {
                 enumtype: None,
                 display: None,
                 is_extension: false,
+                is_undersized: false,
             };
             fields.push(field);
         }

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -96,7 +96,7 @@ impl MavProfile {
                             }
                             assert!(
                                 any_fit,
-                                "bitflag enum field {} of {} must be able to fit at least one possible value {}",
+                                "bitflag enum field {} of {} must be able to fit at least one possible value for {}",
                                 field.name, msg.name, enum_name,
                             );
 
@@ -1171,7 +1171,7 @@ impl MavField {
                     if dsp == "bitmask" {
                         // it is a bitflag
                         if self.is_undersized {
-                            name += ".bits().try_into()? ";
+                            name += ".bits().try_into()?";
                         } else {
                             name += ".bits() as ";
                             name += &self.mavtype.rust_type();

--- a/mavlink-bindgen/tests/definitions/oversized_enum.xml
+++ b/mavlink-bindgen/tests/definitions/oversized_enum.xml
@@ -1,0 +1,19 @@
+<mavlink>
+  <enums>
+    <enum name="GIMBAL_DEVICE_CAP_FLAGS" bitmask="true">
+      <entry value="1" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal device supports a retracted position.</description>
+      </entry>
+      <entry value="131072" name="GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal device supports to point to a global latitude, longitude, altitude position.</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="283" name="GIMBAL_DEVICE_INFORMATION">
+      <description>Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc..</description>
+      <field type="uint16_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS">Bitmap of gimbal capability flags.</field>
+      <field type="uint32_t" name="cap_flags2" enum="GIMBAL_DEVICE_CAP_FLAGS" invalid="0">Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero.</field>
+    </message>
+  </messages>
+</mavlink>   

--- a/mavlink-bindgen/tests/definitions/oversized_enum.xml
+++ b/mavlink-bindgen/tests/definitions/oversized_enum.xml
@@ -16,4 +16,5 @@
       <field type="uint32_t" name="cap_flags2" enum="GIMBAL_DEVICE_CAP_FLAGS" invalid="0">Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero.</field>
     </message>
   </messages>
-</mavlink>   
+</mavlink>
+ 

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -61,3 +61,8 @@ fn snapshot_mav_bool() {
 fn snapshot_mav_cmd() {
     run_snapshot("mav_cmd.xml");
 }
+
+#[test]
+fn snapshot_oversized_enum() {
+    run_snapshot("oversized_enum.xml");
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
@@ -132,14 +132,19 @@ impl MessageData for PING_DATA {
         __struct.target_component = buf.get_u8()?;
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_u64_le(self.time_usec);
         __tmp.put_u32_le(self.seq);
@@ -147,9 +152,9 @@ impl MessageData for PING_DATA {
         __tmp.put_u8(self.target_component);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -215,7 +220,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
             Self::PING(body) => body.ser(version, bytes),
         }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
@@ -98,14 +98,19 @@ impl MessageData for HEARTBEAT_DATA {
         __struct.mavlink_version = buf.get_u8()?;
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_u32_le(self.custom_mode);
         __tmp.put_u8(self.mavtype);
@@ -115,9 +120,9 @@ impl MessageData for HEARTBEAT_DATA {
         __tmp.put_u8(self.mavlink_version);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -180,7 +185,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
             Self::HEARTBEAT(body) => body.ser(version, bytes),
         }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
@@ -103,7 +103,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {}
     }
     fn extra_crc(id: u32) -> u8 {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
@@ -82,23 +82,28 @@ impl MessageData for CUBEPILOT_RAW_RC_DATA {
         }
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         for val in &self.rc_raw {
             __tmp.put_u8(*val);
         }
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -169,7 +174,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
             Self::CUBEPILOT_RAW_RC(body) => body.ser(version, bytes),
         }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__oversized_enum.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__oversized_enum.xml@mod.rs.snap
@@ -1,0 +1,14 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+assertion_line: 26
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "dialect-oversized_enum")]
+pub mod oversized_enum;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__oversized_enum.xml@oversized_enum.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__oversized_enum.xml@oversized_enum.rs.snap
@@ -3,7 +3,7 @@ source: mavlink-bindgen/tests/e2e_snapshots.rs
 assertion_line: 26
 expression: contents
 ---
-#![doc = "MAVLink mav_bool dialect."]
+#![doc = "MAVLink oversized_enum dialect."]
 #![doc = ""]
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
@@ -24,37 +24,35 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ts-rs")]
 use ts_rs::TS;
-bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] # [doc = "Enum used to indicate true or false (also: success or failure, enabled or disabled, active or inactive)."] pub struct MavBool : i8 { # [doc = "False."] const MAV_BOOL_FALSE = 0 ; # [doc = "True."] const MAV_BOOL_TRUE = 1 ; } }
-impl MavBool {
-    pub const DEFAULT: Self = Self::MAV_BOOL_FALSE;
-    pub fn as_bool(&self) -> bool {
-        self.contains(Self::MAV_BOOL_TRUE)
-    }
+bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlags : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; # [doc = "Gimbal device supports to point to a global latitude, longitude, altitude position."] const GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL = 131072 ; } }
+impl GimbalDeviceCapFlags {
+    pub const DEFAULT: Self = Self::GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT;
 }
-impl Default for MavBool {
+impl Default for GimbalDeviceCapFlags {
     fn default() -> Self {
         Self::DEFAULT
     }
 }
-#[doc = "A message with MAV_BOOL."]
+#[doc = "Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc.."]
 #[doc = ""]
-#[doc = "ID: 149"]
+#[doc = "ID: 283"]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
 #[cfg_attr(feature = "ts-rs", derive(TS))]
 #[cfg_attr(feature = "ts-rs", ts(export))]
-pub struct BOOL_TEST_MESSAGE_DATA {
-    #[doc = "unsigned"]
-    pub bool_uint8: MavBool,
-    #[doc = "signed"]
-    pub bool_int8: MavBool,
+pub struct GIMBAL_DEVICE_INFORMATION_DATA {
+    #[doc = "Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero."]
+    pub cap_flags2: GimbalDeviceCapFlags,
+    #[doc = "Bitmap of gimbal capability flags."]
+    #[doc = "This field can not store all possible bitflag values and can cause a serialization error at runtime."]
+    pub cap_flags: GimbalDeviceCapFlags,
 }
-impl BOOL_TEST_MESSAGE_DATA {
-    pub const ENCODED_LEN: usize = 2usize;
+impl GIMBAL_DEVICE_INFORMATION_DATA {
+    pub const ENCODED_LEN: usize = 6usize;
     pub const DEFAULT: Self = Self {
-        bool_uint8: MavBool::DEFAULT,
-        bool_int8: MavBool::DEFAULT,
+        cap_flags2: GimbalDeviceCapFlags::DEFAULT,
+        cap_flags: GimbalDeviceCapFlags::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
     pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
@@ -65,17 +63,17 @@ impl BOOL_TEST_MESSAGE_DATA {
         Self::arbitrary(&mut unstructured).unwrap_or_default()
     }
 }
-impl Default for BOOL_TEST_MESSAGE_DATA {
+impl Default for GIMBAL_DEVICE_INFORMATION_DATA {
     fn default() -> Self {
         Self::DEFAULT.clone()
     }
 }
-impl MessageData for BOOL_TEST_MESSAGE_DATA {
+impl MessageData for GIMBAL_DEVICE_INFORMATION_DATA {
     type Message = MavMessage;
-    const ID: u32 = 149u32;
-    const NAME: &'static str = "BOOL_TEST_MESSAGE";
-    const EXTRA_CRC: u8 = 13u8;
-    const ENCODED_LEN: usize = 2usize;
+    const ID: u32 = 283u32;
+    const NAME: &'static str = "GIMBAL_DEVICE_INFORMATION";
+    const EXTRA_CRC: u8 = 2u8;
+    const ENCODED_LEN: usize = 6usize;
     fn deser(
         _version: MavlinkVersion,
         __input: &[u8],
@@ -90,10 +88,12 @@ impl MessageData for BOOL_TEST_MESSAGE_DATA {
             Bytes::new(__input)
         };
         let mut __struct = Self::default();
-        let tmp = buf.get_u8()?;
-        __struct.bool_uint8 = MavBool::from_bits_retain(tmp as <MavBool as Flags>::Bits);
-        let tmp = buf.get_i8()?;
-        __struct.bool_int8 = MavBool::from_bits_retain(tmp as <MavBool as Flags>::Bits);
+        let tmp = buf.get_u32_le()?;
+        __struct.cap_flags2 =
+            GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
+        let tmp = buf.get_u16_le()?;
+        __struct.cap_flags =
+            GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
         Ok(__struct)
     }
     fn ser(
@@ -110,8 +110,8 @@ impl MessageData for BOOL_TEST_MESSAGE_DATA {
                 },
             );
         }
-        __tmp.put_u8(self.bool_uint8.bits() as u8);
-        __tmp.put_i8(self.bool_int8.bits() as i8);
+        __tmp.put_u32_le(self.cap_flags2.bits() as u32);
+        __tmp.put_u16_le(self.cap_flags.bits().try_into()?);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
             Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
@@ -128,17 +128,20 @@ impl MessageData for BOOL_TEST_MESSAGE_DATA {
 #[cfg_attr(feature = "ts-rs", ts(export))]
 #[repr(u32)]
 pub enum MavMessage {
-    #[doc = "A message with MAV_BOOL."]
+    #[doc = "Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc.."]
     #[doc = ""]
-    #[doc = "ID: 149"]
-    BOOL_TEST_MESSAGE(BOOL_TEST_MESSAGE_DATA),
+    #[doc = "ID: 283"]
+    GIMBAL_DEVICE_INFORMATION(GIMBAL_DEVICE_INFORMATION_DATA),
 }
 impl MavMessage {
     pub const fn all_ids() -> &'static [u32] {
-        &[149u32]
+        &[283u32]
     }
     pub const fn all_messages() -> &'static [(&'static str, u32)] {
-        &[(BOOL_TEST_MESSAGE_DATA::NAME, BOOL_TEST_MESSAGE_DATA::ID)]
+        &[(
+            GIMBAL_DEVICE_INFORMATION_DATA::NAME,
+            GIMBAL_DEVICE_INFORMATION_DATA::ID,
+        )]
     }
 }
 impl Message for MavMessage {
@@ -148,42 +151,43 @@ impl Message for MavMessage {
         payload: &[u8],
     ) -> Result<Self, ::mavlink_core::error::ParserError> {
         match id {
-            BOOL_TEST_MESSAGE_DATA::ID => {
-                BOOL_TEST_MESSAGE_DATA::deser(version, payload).map(Self::BOOL_TEST_MESSAGE)
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => {
+                GIMBAL_DEVICE_INFORMATION_DATA::deser(version, payload)
+                    .map(Self::GIMBAL_DEVICE_INFORMATION)
             }
             _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
         }
     }
     fn message_name(&self) -> &'static str {
         match self {
-            Self::BOOL_TEST_MESSAGE(..) => BOOL_TEST_MESSAGE_DATA::NAME,
+            Self::GIMBAL_DEVICE_INFORMATION(..) => GIMBAL_DEVICE_INFORMATION_DATA::NAME,
         }
     }
     fn message_id(&self) -> u32 {
         match self {
-            Self::BOOL_TEST_MESSAGE(..) => BOOL_TEST_MESSAGE_DATA::ID,
+            Self::GIMBAL_DEVICE_INFORMATION(..) => GIMBAL_DEVICE_INFORMATION_DATA::ID,
         }
     }
     fn message_id_from_name(name: &str) -> Option<u32> {
         match name {
-            BOOL_TEST_MESSAGE_DATA::NAME => Some(BOOL_TEST_MESSAGE_DATA::ID),
+            GIMBAL_DEVICE_INFORMATION_DATA::NAME => Some(GIMBAL_DEVICE_INFORMATION_DATA::ID),
             _ => None,
         }
     }
     fn default_message_from_id(id: u32) -> Option<Self> {
         match id {
-            BOOL_TEST_MESSAGE_DATA::ID => {
-                Some(Self::BOOL_TEST_MESSAGE(BOOL_TEST_MESSAGE_DATA::default()))
-            }
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => Some(Self::GIMBAL_DEVICE_INFORMATION(
+                GIMBAL_DEVICE_INFORMATION_DATA::default(),
+            )),
             _ => None,
         }
     }
     #[cfg(feature = "arbitrary")]
     fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
-            BOOL_TEST_MESSAGE_DATA::ID => {
-                Some(Self::BOOL_TEST_MESSAGE(BOOL_TEST_MESSAGE_DATA::random(rng)))
-            }
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => Some(Self::GIMBAL_DEVICE_INFORMATION(
+                GIMBAL_DEVICE_INFORMATION_DATA::random(rng),
+            )),
             _ => None,
         }
     }
@@ -193,12 +197,12 @@ impl Message for MavMessage {
         bytes: &mut [u8],
     ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
-            Self::BOOL_TEST_MESSAGE(body) => body.ser(version, bytes),
+            Self::GIMBAL_DEVICE_INFORMATION(body) => body.ser(version, bytes),
         }
     }
     fn extra_crc(id: u32) -> u8 {
         match id {
-            BOOL_TEST_MESSAGE_DATA::ID => BOOL_TEST_MESSAGE_DATA::EXTRA_CRC,
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => GIMBAL_DEVICE_INFORMATION_DATA::EXTRA_CRC,
             _ => 0,
         }
     }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -120,22 +120,27 @@ impl MessageData for PARAM_REQUEST_LIST_DATA {
         __struct.target_component = buf.get_u8()?;
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_u8(self.target_system);
         __tmp.put_u8(self.target_component);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -210,14 +215,19 @@ impl MessageData for PARAM_REQUEST_READ_DATA {
         __struct.param_id = CharArray::new(tmp);
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_i16_le(self.param_index);
         __tmp.put_u8(self.target_system);
@@ -227,9 +237,9 @@ impl MessageData for PARAM_REQUEST_READ_DATA {
         }
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -313,14 +323,19 @@ impl MessageData for PARAM_SET_DATA {
             })?;
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_f32_le(self.param_value);
         __tmp.put_u8(self.target_system);
@@ -331,9 +346,9 @@ impl MessageData for PARAM_SET_DATA {
         __tmp.put_u8(self.param_type as u8);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -417,14 +432,19 @@ impl MessageData for PARAM_VALUE_DATA {
             })?;
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_f32_le(self.param_value);
         __tmp.put_u16_le(self.param_count);
@@ -435,9 +455,9 @@ impl MessageData for PARAM_VALUE_DATA {
         __tmp.put_u8(self.param_type as u8);
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -551,7 +571,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
             Self::PARAM_REQUEST_LIST(body) => body.ser(version, bytes),
             Self::PARAM_REQUEST_READ(body) => body.ser(version, bytes),

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
@@ -193,14 +193,19 @@ impl MessageData for SMART_BATTERY_INFO_DATA {
         __struct.device_name = CharArray::new(tmp);
         Ok(__struct)
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         let mut __tmp = BytesMut::new(bytes);
         if __tmp.remaining() < Self::ENCODED_LEN {
-            panic!(
-                "buffer is too small (need {} bytes, but got {})",
-                Self::ENCODED_LEN,
-                __tmp.remaining(),
-            )
+            return Err(
+                ::mavlink_core::error::SerializationError::BufferSizeInsufficient {
+                    encode_len: Self::ENCODED_LEN,
+                    buffer_size: __tmp.remaining(),
+                },
+            );
         }
         __tmp.put_i32_le(self.capacity_full_specification);
         __tmp.put_i32_le(self.capacity_full);
@@ -220,9 +225,9 @@ impl MessageData for SMART_BATTERY_INFO_DATA {
         }
         if matches!(version, MavlinkVersion::V2) {
             let len = __tmp.len();
-            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+            Ok(::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len]))
         } else {
-            __tmp.len()
+            Ok(__tmp.len())
         }
     }
 }
@@ -294,7 +299,11 @@ impl Message for MavMessage {
             _ => None,
         }
     }
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+    fn ser(
+        &self,
+        version: MavlinkVersion,
+        bytes: &mut [u8],
+    ) -> Result<usize, ::mavlink_core::error::SerializationError> {
         match self {
             Self::SMART_BATTERY_INFO(body) => body.ser(version, bytes),
         }

--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -2,6 +2,8 @@ use crate::bytes;
 use core::fmt::{Display, Formatter};
 #[cfg(feature = "std")]
 use std::error::Error;
+#[cfg(feature = "std")]
+use std::num::TryFromIntError;
 
 /// Error while parsing a MAVLink message
 #[derive(Debug)]
@@ -35,6 +37,46 @@ impl Display for ParserError {
 
 #[cfg(feature = "std")]
 impl Error for ParserError {}
+
+#[derive(Debug)]
+/// Error while serializing a MAVLink message
+pub enum SerializationError {
+    /// A bitflag value can not be stored in a fields datatype
+    BitflagValueOverflow(TryFromIntError),
+    /// Message does not fit in the provided buffer
+    BufferSizeInsufficient {
+        buffer_size: usize,
+        encode_len: usize,
+    },
+}
+
+impl From<TryFromIntError> for SerializationError {
+    fn from(error: TryFromIntError) -> Self {
+        Self::BitflagValueOverflow(error)
+    }
+}
+
+impl Display for SerializationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BitflagValueOverflow(error) => {
+                write!(f, "Bitflag value does not fit in field: {error}")
+            }
+            Self::BufferSizeInsufficient {
+                buffer_size,
+                encode_len,
+            } => {
+                write!(
+                    f,
+                    "buffer is too small (need {encode_len} bytes, but got {buffer_size})"
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for SerializationError {}
 
 /// Error while reading and parsing a MAVLink message
 #[derive(Debug)]
@@ -97,6 +139,8 @@ pub enum MessageWriteError {
     Io,
     /// Message does not support MAVLink 1
     MAVLink2Only,
+    /// Error during serialization
+    SerializationError(SerializationError),
 }
 
 impl Display for MessageWriteError {
@@ -107,6 +151,7 @@ impl Display for MessageWriteError {
             #[cfg(all(feature = "embedded", not(feature = "std")))]
             Self::Io => write!(f, "Failed to write message"),
             Self::MAVLink2Only => write!(f, "Message is not supported in MAVLink 1"),
+            Self::SerializationError(e) => write!(f, "Failed to serialize message: {e:#?}"),
         }
     }
 }
@@ -118,5 +163,11 @@ impl Error for MessageWriteError {}
 impl From<std::io::Error> for MessageWriteError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+impl From<SerializationError> for MessageWriteError {
+    fn from(e: SerializationError) -> Self {
+        Self::SerializationError(e)
     }
 }

--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -1,5 +1,7 @@
 use crate::bytes;
 use core::fmt::{Display, Formatter};
+#[cfg(not(feature = "std"))]
+use core::num::TryFromIntError;
 #[cfg(feature = "std")]
 use std::error::Error;
 #[cfg(feature = "std")]

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -101,7 +101,7 @@ use peek_reader::PeekReader;
 
 use crate::{
     bytes::Bytes,
-    error::{MessageReadError, MessageWriteError, ParserError},
+    error::{MessageReadError, MessageWriteError, ParserError, SerializationError},
 };
 
 use crc_any::CRCu16;
@@ -192,10 +192,10 @@ where
 
     /// Serialize **Message** into byte slice and return count of bytes written
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the buffer provided is to small to store this message
-    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize;
+    /// Will return an error if the buffer provided is to small to store this message or when a bitflag value has an invalid value for a field
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> Result<usize, SerializationError>;
 
     /// Parse a Message from its message id and payload bytes
     ///
@@ -226,10 +226,11 @@ pub trait MessageData: Sized {
     const EXTRA_CRC: u8;
     const ENCODED_LEN: usize;
 
-    /// # Panics
+    /// # Errors
     ///
-    /// Will panic if the buffer provided is to small to hold the full message payload of the implementing message type
-    fn ser(&self, version: MavlinkVersion, payload: &mut [u8]) -> usize;
+    /// Will return an error if the buffer provided is to small to hold the full message payload of the implementing message type or when a bitflag value has an invalid value for a field
+    fn ser(&self, version: MavlinkVersion, payload: &mut [u8])
+    -> Result<usize, SerializationError>;
     /// # Errors
     ///
     /// Will return [`ParserError::InvalidEnum`] on a nonexistent enum value and
@@ -301,14 +302,19 @@ impl<M: Message> MavFrame<M> {
     ///
     /// # Panics
     ///
-    /// - If the frame does not fit in the provided buffer
+    ///
     /// - When attempting to serialize a message with an id greater then 255 with MAVLink 1
-    pub fn ser(&self, buf: &mut [u8]) -> usize {
+    ///
+    /// # Errors
+    ///
+    /// - If the frame does not fit in the provided buffer
+    /// - When a bitflag value has an invalid value for a field
+    pub fn ser(&self, buf: &mut [u8]) -> Result<usize, SerializationError> {
         let mut buf = bytes_mut::BytesMut::new(buf);
 
         // serialize message
         let mut payload_buf = [0u8; 255];
-        let payload_len = self.msg.ser(self.protocol_version, &mut payload_buf);
+        let payload_len = self.msg.ser(self.protocol_version, &mut payload_buf)?;
 
         // Currently expects a buffer with the sequence field at the start.
         // If this is updated to include the initial packet marker, length field, and flags,
@@ -349,7 +355,7 @@ impl<M: Message> MavFrame<M> {
         }
 
         buf.put_slice(&payload_buf[..payload_len]);
-        buf.len()
+        Ok(buf.len())
     }
 
     /// Deserialize MavFrame from a slice that has been received from, for example, a socket.
@@ -755,9 +761,17 @@ impl MAVLinkV1MessageRaw {
     /// # Panics
     ///
     /// If the message's id exceeds 255 and is therefore not supported for MAVLink 1
-    pub fn serialize_message<M: Message>(&mut self, header: MavHeader, message: &M) {
+    ///
+    /// # Errors
+    ///
+    /// When a bitflag value has an invalid value for a field an error is returned
+    pub fn serialize_message<M: Message>(
+        &mut self,
+        header: MavHeader,
+        message: &M,
+    ) -> Result<(), SerializationError> {
         let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
-        let payload_length = message.ser(MavlinkVersion::V1, payload_buf);
+        let payload_length = message.ser(MavlinkVersion::V1, payload_buf)?;
 
         let message_id = message.message_id();
         self.serialize_stx_and_header_and_crc(
@@ -766,16 +780,26 @@ impl MAVLinkV1MessageRaw {
             payload_length,
             M::extra_crc(message_id),
         );
+        Ok(())
     }
 
     /// # Panics
     ///
     /// If the `MessageData`'s `ID` exceeds 255 and is therefore not supported for MAVLink 1
-    pub fn serialize_message_data<D: MessageData>(&mut self, header: MavHeader, message_data: &D) {
+    ///
+    /// # Errors
+    ///
+    /// When a bitflag value has an invalid value for a field an error is returned
+    pub fn serialize_message_data<D: MessageData>(
+        &mut self,
+        header: MavHeader,
+        message_data: &D,
+    ) -> Result<(), SerializationError> {
         let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
-        let payload_length = message_data.ser(MavlinkVersion::V1, payload_buf);
+        let payload_length = message_data.ser(MavlinkVersion::V1, payload_buf)?;
 
         self.serialize_stx_and_header_and_crc(header, D::ID, payload_length, D::EXTRA_CRC);
+        Ok(())
     }
 }
 
@@ -1295,9 +1319,17 @@ impl MAVLinkV2MessageRaw {
     /// Serialize a [Message] with a given header into this raw message buffer.
     ///
     /// This does not set any compatiblity or incompatiblity flags.
-    pub fn serialize_message<M: Message>(&mut self, header: MavHeader, message: &M) {
+    ///
+    /// # Errors
+    ///
+    /// When a bitflag value has an invalid value for a field an error is returned
+    pub fn serialize_message<M: Message>(
+        &mut self,
+        header: MavHeader,
+        message: &M,
+    ) -> Result<(), SerializationError> {
         let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
-        let payload_length = message.ser(MavlinkVersion::V2, payload_buf);
+        let payload_length = message.ser(MavlinkVersion::V2, payload_buf)?;
 
         let message_id = message.message_id();
         self.serialize_stx_and_header_and_crc(
@@ -1307,15 +1339,24 @@ impl MAVLinkV2MessageRaw {
             M::extra_crc(message_id),
             0,
         );
+        Ok(())
     }
 
     /// Serialize a [Message] with a given header into this raw message buffer and sets the `MAVLINK_IFLAG_SIGNED` incompatiblity flag.
     ///
     /// This does not update the message's signature fields.
     /// This does not set any compatiblity flags.
-    pub fn serialize_message_for_signing<M: Message>(&mut self, header: MavHeader, message: &M) {
+    ///
+    /// # Errors
+    ///
+    /// When a bitflag value has an invalid value for a field an error is returned
+    pub fn serialize_message_for_signing<M: Message>(
+        &mut self,
+        header: MavHeader,
+        message: &M,
+    ) -> Result<(), SerializationError> {
         let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
-        let payload_length = message.ser(MavlinkVersion::V2, payload_buf);
+        let payload_length = message.ser(MavlinkVersion::V2, payload_buf)?;
 
         let message_id = message.message_id();
         self.serialize_stx_and_header_and_crc(
@@ -1325,13 +1366,19 @@ impl MAVLinkV2MessageRaw {
             M::extra_crc(message_id),
             MAVLINK_IFLAG_SIGNED,
         );
+        Ok(())
     }
 
-    pub fn serialize_message_data<D: MessageData>(&mut self, header: MavHeader, message_data: &D) {
+    pub fn serialize_message_data<D: MessageData>(
+        &mut self,
+        header: MavHeader,
+        message_data: &D,
+    ) -> Result<(), SerializationError> {
         let payload_buf = &mut self.0[(1 + Self::HEADER_SIZE)..(1 + Self::HEADER_SIZE + 255)];
-        let payload_length = message_data.ser(MavlinkVersion::V2, payload_buf);
+        let payload_length = message_data.ser(MavlinkVersion::V2, payload_buf)?;
 
         self.serialize_stx_and_header_and_crc(header, D::ID, payload_length, D::EXTRA_CRC, 0);
+        Ok(())
     }
 }
 
@@ -2043,7 +2090,7 @@ pub fn write_v2_msg<M: Message, W: Write>(
     data: &M,
 ) -> Result<usize, MessageWriteError> {
     let mut message_raw = MAVLinkV2MessageRaw::new();
-    message_raw.serialize_message(header, data);
+    message_raw.serialize_message(header, data)?;
 
     let payload_length: usize = message_raw.payload_length().into();
     let len = 1 + MAVLinkV2MessageRaw::HEADER_SIZE + payload_length + 2;
@@ -2189,7 +2236,7 @@ pub fn write_v1_msg<M: Message, W: Write>(
         return Err(MessageWriteError::MAVLink2Only);
     }
     let mut message_raw = MAVLinkV1MessageRaw::new();
-    message_raw.serialize_message(header, data);
+    message_raw.serialize_message(header, data)?;
 
     let payload_length: usize = message_raw.payload_length().into();
     let len = 1 + MAVLinkV1MessageRaw::HEADER_SIZE + payload_length + 2;

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -2116,15 +2116,15 @@ pub fn write_v2_msg_signed<M: Message, W: Write>(
 
     let signature_len = if let Some(signing_data) = signing_data {
         if signing_data.config.sign_outgoing {
-            message_raw.serialize_message_for_signing(header, data);
+            message_raw.serialize_message_for_signing(header, data)?;
             signing_data.sign_message(&mut message_raw);
             MAVLinkV2MessageRaw::SIGNATURE_SIZE
         } else {
-            message_raw.serialize_message(header, data);
+            message_raw.serialize_message(header, data)?;
             0
         }
     } else {
-        message_raw.serialize_message(header, data);
+        message_raw.serialize_message(header, data)?;
         0
     };
 
@@ -2148,7 +2148,7 @@ pub async fn write_v2_msg_async<M: Message, W: AsyncWrite + Unpin>(
     data: &M,
 ) -> Result<usize, MessageWriteError> {
     let mut message_raw = MAVLinkV2MessageRaw::new();
-    message_raw.serialize_message(header, data);
+    message_raw.serialize_message(header, data)?;
 
     let payload_length: usize = message_raw.payload_length().into();
     let len = 1 + MAVLinkV2MessageRaw::HEADER_SIZE + payload_length + 2;
@@ -2175,15 +2175,15 @@ pub async fn write_v2_msg_async_signed<M: Message, W: AsyncWrite + Unpin>(
 
     let signature_len = if let Some(signing_data) = signing_data {
         if signing_data.config.sign_outgoing {
-            message_raw.serialize_message_for_signing(header, data);
+            message_raw.serialize_message_for_signing(header, data)?;
             signing_data.sign_message(&mut message_raw);
             MAVLinkV2MessageRaw::SIGNATURE_SIZE
         } else {
-            message_raw.serialize_message(header, data);
+            message_raw.serialize_message(header, data)?;
             0
         }
     } else {
-        message_raw.serialize_message(header, data);
+        message_raw.serialize_message(header, data)?;
         0
     };
 
@@ -2261,7 +2261,7 @@ pub async fn write_v1_msg_async<M: Message, W: AsyncWrite + Unpin>(
         return Err(MessageWriteError::MAVLink2Only);
     }
     let mut message_raw = MAVLinkV1MessageRaw::new();
-    message_raw.serialize_message(header, data);
+    message_raw.serialize_message(header, data)?;
 
     let payload_length: usize = message_raw.payload_length().into();
     let len = 1 + MAVLinkV1MessageRaw::HEADER_SIZE + payload_length + 2;

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -2285,7 +2285,7 @@ pub async fn write_v1_msg_async<M: Message>(
         return Err(MessageWriteError::MAVLink2Only);
     }
     let mut message_raw = MAVLinkV1MessageRaw::new();
-    message_raw.serialize_message(header, data);
+    message_raw.serialize_message(header, data)?;
 
     let payload_length: usize = message_raw.payload_length().into();
     let len = 1 + MAVLinkV1MessageRaw::HEADER_SIZE + payload_length + 2;

--- a/mavlink/tests/mav_frame_tests.rs
+++ b/mavlink/tests/mav_frame_tests.rs
@@ -40,7 +40,7 @@ mod mav_frame_tests {
         let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
 
         let mut buffer = [0u8; HEARTBEAT_V2.len()];
-        frame.ser(&mut buffer);
+        frame.ser(&mut buffer).unwrap();
         assert_eq!(buffer[..buffer.len() - 2], HEARTBEAT_V2[..buffer.len() - 2]);
 
         let msg = match frame.msg {

--- a/mavlink/tests/v1_encode_decode_tests.rs
+++ b/mavlink/tests/v1_encode_decode_tests.rs
@@ -79,7 +79,9 @@ mod test_v1_encode_decode {
         let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
         let mut raw_msg = mavlink::MAVLinkV1MessageRaw::new();
 
-        raw_msg.serialize_message_data(crate::test_shared::COMMON_MSG_HEADER, &heartbeat_msg);
+        raw_msg
+            .serialize_message_data(crate::test_shared::COMMON_MSG_HEADER, &heartbeat_msg)
+            .unwrap();
 
         assert_eq!(raw_msg.raw_bytes(), HEARTBEAT_V1);
         assert!(raw_msg.has_valid_crc::<mavlink::dialects::common::MavMessage>());

--- a/mavlink/tests/v2_encode_decode_tests.rs
+++ b/mavlink/tests/v2_encode_decode_tests.rs
@@ -143,7 +143,9 @@ mod test_v2_encode_decode {
         let heartbeat_msg = crate::test_shared::get_heartbeat_msg();
         let mut raw_msg = mavlink::MAVLinkV2MessageRaw::new();
 
-        raw_msg.serialize_message_data(crate::test_shared::COMMON_MSG_HEADER, &heartbeat_msg);
+        raw_msg
+            .serialize_message_data(crate::test_shared::COMMON_MSG_HEADER, &heartbeat_msg)
+            .unwrap();
 
         assert_eq!(raw_msg.raw_bytes(), HEARTBEAT_V2);
         assert!(raw_msg.has_valid_crc::<mavlink::dialects::common::MavMessage>());


### PR DESCRIPTION
Fixes #495

Since all `ser` and related function return a result now this is very much breaking. 
Also turned the panic on too small buffer size into an error, same should eventually also be done for the case of message ids over 255 if tried to use them with Mavlink1.

I would also like to add a test that checks that the error is actually generated, but that needs the updated mavlink definitions.
