### PR TITLE
speed up crc computation by migrating to crc-fast

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ byteorder = { version = "1.3.4", default-features = false }
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85.0"
+rust-version = "1.89.0"
 keywords = ["mavlink", "parser", "protocol", "embedded"]
 categories = ["aerospace", "aerospace::protocols", "parsing", "embedded"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["mavlink", "mavlink-bindgen", "mavlink-core"]
-resolver = "1"
+resolver = "2"
 
 [workspace.dependencies]
 crc-fast = { version = "1.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["mavlink", "mavlink-bindgen", "mavlink-core"]
 resolver = "1"
 
 [workspace.dependencies]
-crc-any = { version = "2.3.5", default-features = false }
+crc-fast = { version = "1.10", default-features = false }
 num-traits = { version = "0.2", default-features = false }
 num-derive = "0.4"
 bitflags = { version = "2.9.1", default-features = false }

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -20,7 +20,7 @@ arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 clap = { version = "~4.6.0", optional = true, default-features =false, features = ["derive", "help", "usage", "error-context"] }
 clap_builder = { version = "4.3.24", optional = true}
 clap_lex = { version = "1.0.0", optional = true }
-crc-any = { workspace = true, default-features = false }
+crc-fast = { workspace = true, default-features = false }
 proc-macro2 = "1.0.43"
 quick-xml = "0.40"
 quote = "1"

--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -20,7 +20,7 @@ arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 clap = { version = "~4.6.0", optional = true, default-features =false, features = ["derive", "help", "usage", "error-context"] }
 clap_builder = { version = "4.3.24", optional = true}
 clap_lex = { version = "1.0.0", optional = true }
-crc-fast = { workspace = true, default-features = false }
+crc-fast = { workspace = true, default-features = false, features = ["std"] }
 proc-macro2 = "1.0.43"
 quick-xml = "0.40"
 quote = "1"

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1,4 +1,4 @@
-use crc_any::CRCu16;
+use crc_fast::{CrcAlgorithm, Digest as CrcDigest};
 use std::cmp::Ordering;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashSet};
@@ -2099,32 +2099,36 @@ pub fn generate<W: Write>(
 /// needed for generating sensible rust code), but for calculating crc function we have to
 /// use the original name "type"
 pub fn extra_crc(msg: &MavMessage) -> u8 {
-    // calculate a 8-bit checksum of the key fields of a message, so we
-    // can detect incompatible XML changes
-    let mut crc = CRCu16::crc16mcrf4cc();
+    let mut crc = CrcDigest::new(CrcAlgorithm::Crc16Mcrf4xx);
 
-    crc.digest(msg.name.as_bytes());
-    crc.digest(b" ");
+    crc.update(msg.name.as_bytes());
+    crc.update(b" ");
 
-    let mut f = msg.fields.clone();
-    // only mavlink 1 fields should be part of the extra_crc
-    f.retain(|f| !f.is_extension);
-    f.sort_by(|a, b| a.mavtype.compare(&b.mavtype));
-    for field in &f {
-        crc.digest(field.mavtype.primitive_type().as_bytes());
-        crc.digest(b" ");
+    let mut fields = msg.fields.clone();
+
+    // Mavlink 2 extension fields are not part of CRC_EXTRA.
+    fields.retain(|field| !field.is_extension);
+
+    fields.sort_by(|left, right| left.mavtype.compare(&right.mavtype));
+
+    for field in &fields {
+        crc.update(field.mavtype.primitive_type().as_bytes());
+        crc.update(b" ");
+
         if field.name == "mavtype" {
-            crc.digest(b"type");
+            crc.update(b"type");
         } else {
-            crc.digest(field.name.as_bytes());
+            crc.update(field.name.as_bytes());
         }
-        crc.digest(b" ");
+
+        crc.update(b" ");
+
         if let MavType::Array(_, size) | MavType::CharArray(size) = field.mavtype {
-            crc.digest(&[size as u8]);
+            crc.update(&[size as u8]);
         }
     }
 
-    let crcval = crc.get_crc();
+    let crcval = crc.finalize() as u16;
     ((crcval & 0xFF) ^ (crcval >> 8)) as u8
 }
 

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -1801,10 +1801,9 @@ pub fn parse_profile(
                                     // Update field display if enum is a bitmask
                                     if let Some(e) =
                                         profile.enums.get(field.enumtype.as_ref().unwrap())
+                                        && e.bitmask
                                     {
-                                        if e.bitmask {
-                                            field.display = Some("bitmask".to_string());
-                                        }
+                                        field.display = Some("bitmask".to_string());
                                     }
                                 }
                                 b"display" => {

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -22,7 +22,7 @@ categories.workspace = true
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 async-trait = { version = "0.1.18", optional = true }
 byteorder = { workspace = true, default-features = false }
-crc-any = { workspace = true, default-features = false }
+crc-fast = { workspace = true, default-features = false }
 embedded-io = { version = "0.7", optional = true }
 embedded-io-async = { version = "0.7", optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
@@ -43,11 +43,11 @@ default = [
     "serde",
 ]
 
-std = ["byteorder/std"]
+std = ["byteorder/std", "crc-fast/std"]
 transport-udp = []
 transport-tcp = []
 transport-direct-serial = ["serialport"]
-embedded = ["dep:embedded-io", "dep:embedded-io-async"]
+embedded = ["dep:embedded-io", "dep:embedded-io-async", "crc-fast/panic-handler"]
 serde = ["dep:serde", "dep:serde_arrays"]
 tokio = [
     "dep:tokio",

--- a/mavlink-core/src/connection/udp/async.rs
+++ b/mavlink-core/src/connection/udp/async.rs
@@ -106,10 +106,10 @@ impl AsyncUdpConnection {
     }
 
     async fn update_reply_destination(&self, reader: &mut AsyncPeekReader<UdpRead>) {
-        if self.server {
-            if let addr @ Some(_) = reader.reader_ref().last_recv_address {
-                self.writer.lock().await.dest = addr;
-            }
+        if self.server
+            && let addr @ Some(_) = reader.reader_ref().last_recv_address
+        {
+            self.writer.lock().await.dest = addr;
         }
     }
 }

--- a/mavlink-core/src/connection/udp/sync.rs
+++ b/mavlink-core/src/connection/udp/sync.rs
@@ -75,10 +75,10 @@ impl UdpConnection {
     }
 
     fn update_reply_destination(&self, reader: &PeekReader<UdpRead>) {
-        if self.server {
-            if let addr @ Some(_) = reader.reader_ref().last_recv_address {
-                self.writer.lock().unwrap().dest = addr;
-            }
+        if self.server
+            && let addr @ Some(_) = reader.reader_ref().last_recv_address
+        {
+            self.writer.lock().unwrap().dest = addr;
         }
     }
 }

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -1368,10 +1368,10 @@ fn try_decode_v2<M: Message, R: Read>(
     }
 
     #[cfg(feature = "mav2-message-signing")]
-    if let Some(signing_data) = signing_data {
-        if !signing_data.verify_signature(&message) {
-            return Ok(None);
-        }
+    if let Some(signing_data) = signing_data
+        && !signing_data.verify_signature(&message)
+    {
+        return Ok(None);
     }
 
     Ok(Some(message))
@@ -1411,10 +1411,10 @@ async fn try_decode_v2_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     }
 
     #[cfg(feature = "mav2-message-signing")]
-    if let Some(signing_data) = signing_data {
-        if !signing_data.verify_signature(&message) {
-            return Ok(None);
-        }
+    if let Some(signing_data) = signing_data
+        && !signing_data.verify_signature(&message)
+    {
+        return Ok(None);
     }
 
     Ok(Some(message))

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -104,7 +104,7 @@ use crate::{
     error::{MessageReadError, MessageWriteError, ParserError},
 };
 
-use crc_any::CRCu16;
+use crc_fast::{CrcAlgorithm, Digest as CrcDigest};
 
 #[doc(hidden)]
 pub mod bytes;
@@ -139,7 +139,7 @@ mod signing;
 #[cfg(feature = "mav2-message-signing")]
 pub use self::signing::{SigningConfig, SigningData};
 #[cfg(feature = "mav2-message-signing")]
-use sha2::{Digest, Sha256};
+use sha2::{Digest as Sha256Digest, Sha256};
 
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
@@ -401,11 +401,10 @@ impl<M: Message> MavFrame<M> {
 
 /// Calculates the [CRC checksum](https://mavlink.io/en/guide/serialization.html#checksum) of a messages header, payload and the CRC_EXTRA byte.
 pub fn calculate_crc(data: &[u8], extra_crc: u8) -> u16 {
-    let mut crc_calculator = CRCu16::crc16mcrf4cc();
-    crc_calculator.digest(data);
-
-    crc_calculator.digest(&[extra_crc]);
-    crc_calculator.get_crc()
+    let mut crc_calculator = CrcDigest::new(CrcAlgorithm::Crc16Mcrf4xx);
+    crc_calculator.update(data);
+    crc_calculator.update(&[extra_crc]);
+    crc_calculator.finalize() as u16
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/mavlink/build/main.rs
+++ b/mavlink/build/main.rs
@@ -18,17 +18,16 @@ fn main() -> ExitCode {
         .unwrap_or(true);
     let is_submodule = mavlink_dir.join(".git").exists() || is_mavlink_empty;
 
-    if is_submodule {
-        if let Err(error) = Command::new("git")
+    if is_submodule
+        && let Err(error) = Command::new("git")
             .arg("submodule")
             .arg("update")
             .arg("--init")
             .current_dir(src_dir)
             .status()
-        {
-            eprintln!("Failed to update MAVLink definitions submodule: {error}");
-            return ExitCode::FAILURE;
-        }
+    {
+        eprintln!("Failed to update MAVLink definitions submodule: {error}");
+        return ExitCode::FAILURE;
     }
 
     // find & apply patches to XML definitions to avoid crashes


### PR DESCRIPTION
A basic benchmark comparison  I ran on an RP5:

```sh
workload                               frames    crc bytes     passes   crc-any ns/crc  crc-fast ns/crc    speedup

command_long v2                             1           39    3441480           156.41            74.53      2.10x
heartbeat v2                               46          828     162098            82.98            72.57      1.14x
servo_output_raw v2                        37         1702      78858           181.34            75.82      2.39x
raw_imu v2                                 37         1406      95460           153.21            75.84      2.02x
gps_raw_int v2                             37         2257      59467           234.13            77.18      3.03x
system_time v2                             36          756     177536            93.56            72.42      1.29x
```

So we get a good amount of speed simply by replacing the dependency.

Note that `crc-fast` is not only a faster CRC implementation but it is also more widely used. According to crates.io, as of today, it has over 18 million more downloads than `crc-any`.

Blocked by: https://github.com/awesomized/crc-fast-rust/pull/49