### PR TITLE
Generate undersized bitflag variants when fields are undersized

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -85,17 +85,21 @@ impl MavProfile {
                         if enm.bitmask {
                             enm.primitive = Some(field.mavtype.rust_primitive_type());
 
-                            // check if all enum values can be stored in the fields
+                            // check if any enum values can be stored in the fields
+                            let mut any_fit = false;
                             for entry in &enm.entries {
-                                assert!(
-                                    entry.value.unwrap_or_default()
-                                        <= field.mavtype.max_int_value(),
-                                    "bitflag enum field {} of {} must be able to fit all possible values for {}",
-                                    field.name,
-                                    msg.name,
-                                    enum_name,
-                                );
+                                if field.mavtype.max_int_value() < entry.value.unwrap_or_default() {
+                                    field.is_undersized = true;
+                                    enm.additional_primives.insert(field.mavtype.clone());
+                                } else {
+                                    any_fit = true;
+                                }
                             }
+                            assert!(
+                                any_fit,
+                                "bitflag enum field {} of {} must be able to fit at least one possible value {}",
+                                field.name, msg.name, enum_name,
+                            );
 
                             // Fix fields in backwards manner
                             if field.display.is_none() {
@@ -523,6 +527,7 @@ pub struct MavEnum {
     pub primitive: Option<String>,
     pub bitmask: bool,
     pub deprecated: Option<MavDeprecation>,
+    pub additional_primives: HashSet<MavType>,
 }
 
 impl MavEnum {
@@ -542,16 +547,17 @@ impl MavEnum {
                     None => self.entries.push(enum_entry.clone()),
                 }
             }
+            self.additional_primives
+                .extend(enm.additional_primives.clone());
         }
     }
 
-    fn emit_defs(&self) -> Vec<TokenStream> {
+    fn emit_defs(&self, max_value: u64) -> Vec<TokenStream> {
         let mut cnt = 0u64;
         self.entries
             .iter()
             .map(|enum_entry| {
                 let name = format_ident!("{}", enum_entry.name.clone());
-                let value;
 
                 let deprecation = enum_entry.emit_deprecation();
 
@@ -564,37 +570,47 @@ impl MavEnum {
 
                 let params_doc = enum_entry.emit_params();
 
-                if let Some(tmp_value) = enum_entry.value {
+                let value = if let Some(tmp_value) = enum_entry.value {
                     cnt = cnt.max(tmp_value);
-                    let tmp = TokenStream::from_str(&tmp_value.to_string()).unwrap();
-                    value = quote!(#tmp);
+                    tmp_value
                 } else {
                     cnt += 1;
-                    value = quote!(#cnt);
-                }
+                    cnt
+                };
 
-                if self.is_generated_as_bitflags() {
-                    quote! {
-                        #deprecation
-                        #description
-                        #params_doc
-                        const #name = #value;
+                if value <= max_value {
+                    let value = TokenStream::from_str(&value.to_string()).unwrap();
+                    if self.is_generated_as_bitflags() {
+                        quote! {
+                            #deprecation
+                            #description
+                            #params_doc
+                            const #name = #value;
+                        }
+                    } else {
+                        quote! {
+                            #deprecation
+                            #description
+                            #params_doc
+                            #name = #value,
+                        }
                     }
                 } else {
-                    quote! {
-                        #deprecation
-                        #description
-                        #params_doc
-                        #name = #value,
-                    }
+                    quote!()
                 }
             })
             .collect()
     }
 
     #[inline(always)]
-    fn emit_name(&self) -> TokenStream {
-        let name = format_ident!("{}", self.name);
+    fn emit_name(&self, additional_primitive: Option<MavType>) -> TokenStream {
+        let name = format_ident!(
+            "{}{}",
+            self.name,
+            &additional_primitive
+                .map(|s| s.primitive_type().to_uppercase())
+                .unwrap_or_default()
+        );
         quote!(#name)
     }
 
@@ -613,8 +629,22 @@ impl MavEnum {
     }
 
     fn emit_rust(&self) -> TokenStream {
-        let defs = self.emit_defs();
-        let enum_name = self.emit_name();
+        let base = self.emit_enum_def(None);
+        let adds = self.emit_additional_primitives();
+        quote! {
+            #base
+            #adds
+        }
+    }
+
+    fn emit_enum_def(&self, restricted_primitive: Option<MavType>) -> TokenStream {
+        let defs = self.emit_defs(
+            restricted_primitive
+                .as_ref()
+                .map(|t| t.max_int_value())
+                .unwrap_or(u64::MAX),
+        );
+        let enum_name = self.emit_name(restricted_primitive);
         let const_default = self.emit_const_default();
 
         let deprecated = self.emit_deprecation();
@@ -649,10 +679,9 @@ impl MavEnum {
             quote!()
         };
 
-        let enum_def;
-        if let Some(primitive) = self.primitive.clone() {
+        let enum_def = if let Some(primitive) = self.primitive.clone() {
             let primitive = format_ident!("{}", primitive);
-            enum_def = quote! {
+            quote! {
                 bitflags!{
                     #[cfg_attr(feature = "ts-rs", derive(TS))]
                     #[cfg_attr(feature = "ts-rs", ts(export, type = "number"))]
@@ -665,9 +694,9 @@ impl MavEnum {
                         #(#defs)*
                     }
                 }
-            };
+            }
         } else {
-            enum_def = quote! {
+            quote! {
                 #[cfg_attr(feature = "ts-rs", derive(TS))]
                 #[cfg_attr(feature = "ts-rs", ts(export))]
                 #[derive(Debug, Copy, Clone, PartialEq, FromPrimitive, ToPrimitive)]
@@ -680,8 +709,8 @@ impl MavEnum {
                 pub enum #enum_name {
                     #(#defs)*
                 }
-            };
-        }
+            }
+        };
 
         quote! {
             #enum_def
@@ -697,6 +726,14 @@ impl MavEnum {
                 }
             }
         }
+    }
+
+    fn emit_additional_primitives(&self) -> TokenStream {
+        let mut ts = TokenStream::new();
+        for primitive in &self.additional_primives {
+            ts.extend(self.emit_enum_def(Some(primitive.clone())));
+        }
+        ts
     }
 }
 
@@ -1108,6 +1145,7 @@ pub struct MavField {
     pub enumtype: Option<String>,
     pub display: Option<String>,
     pub is_extension: bool,
+    pub is_undersized: bool,
 }
 
 impl MavField {
@@ -1126,8 +1164,18 @@ impl MavField {
             let rt = TokenStream::from_str(&self.mavtype.rust_type()).unwrap();
             mavtype = quote!(#rt);
         } else if let Some(enumname) = &self.enumtype {
-            let en = TokenStream::from_str(enumname).unwrap();
-            mavtype = quote!(#en);
+            if self.is_undersized {
+                let en = TokenStream::from_str(&format!(
+                    "{}{}",
+                    enumname,
+                    self.mavtype.rust_primitive_type().to_uppercase()
+                ))
+                .unwrap();
+                mavtype = quote!(#en);
+            } else {
+                let en = TokenStream::from_str(enumname).unwrap();
+                mavtype = quote!(#en);
+            }
         } else {
             let rt = TokenStream::from_str(&self.mavtype.rust_type()).unwrap();
             mavtype = quote!(#rt);
@@ -1142,6 +1190,9 @@ impl MavField {
         if let Some(val) = self.description.as_ref() {
             let desc = URL_REGEX.replace_all(val, "<$1>");
             ts.extend(quote!(#[doc = #desc]));
+        }
+        if self.is_undersized {
+            ts.extend(quote!(#[doc = "This field can not store all possible values of its associated bitflag enum."]));
         }
         ts
     }
@@ -1240,7 +1291,7 @@ impl MavField {
     }
 }
 
-#[derive(Debug, PartialEq, Clone, Default)]
+#[derive(Debug, PartialEq, Clone, Default, Hash, Eq)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum MavType {
     UInt8MavlinkVersion,
@@ -2302,6 +2353,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2310,6 +2362,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2326,6 +2379,7 @@ mod tests {
                 enumtype: None,
                 display: None,
                 is_extension: false,
+                is_undersized: false,
             }],
             deprecated: None,
         };
@@ -2364,6 +2418,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt16,
@@ -2372,6 +2427,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2395,6 +2451,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2403,6 +2460,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2425,6 +2483,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
                 MavField {
                     mavtype: MavType::UInt8,
@@ -2433,6 +2492,7 @@ mod tests {
                     enumtype: None,
                     display: None,
                     is_extension: false,
+                    is_undersized: false,
                 },
             ],
             deprecated: None,
@@ -2453,6 +2513,7 @@ mod tests {
                 enumtype: None,
                 display: None,
                 is_extension: false,
+                is_undersized: false,
             };
             fields.push(field);
         }

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -83,14 +83,14 @@ impl MavProfile {
 
                         // it is a bitmask
                         if enm.bitmask {
-                            enm.primitive = Some(field.mavtype.rust_primitive_type());
-
                             // check if any enum values can be stored in the fields
                             let mut any_fit = false;
+                            let mut all_fit = true;
                             for entry in &enm.entries {
                                 if field.mavtype.max_int_value() < entry.value.unwrap_or_default() {
                                     field.is_undersized = true;
                                     enm.additional_primives.insert(field.mavtype.clone());
+                                    all_fit = false;
                                 } else {
                                     any_fit = true;
                                 }
@@ -101,6 +101,10 @@ impl MavProfile {
                                 field.name, msg.name, enum_name,
                             );
 
+                            if all_fit {
+                                enm.primitive = Some(field.mavtype.clone());
+                            }
+
                             // Fix fields in backwards manner
                             if field.display.is_none() {
                                 field.display = Some("bitmask".to_string());
@@ -108,6 +112,22 @@ impl MavProfile {
                         }
                     }
                 }
+            }
+        }
+        for enm in self.enums.values_mut() {
+            if enm.bitmask && enm.primitive.is_none() {
+                let max = enm
+                    .entries
+                    .iter()
+                    .filter_map(|e| e.value)
+                    .max()
+                    .unwrap_or_default();
+                let primitive = match max {
+                    max if max <= u16::MAX as u64 => MavType::UInt16,
+                    max if max <= u32::MAX as u64 => MavType::UInt32,
+                    _ => MavType::UInt64,
+                };
+                enm.primitive = Some(primitive);
             }
         }
         self
@@ -524,7 +544,7 @@ pub struct MavEnum {
     /// If contains Some, the string represents the primitive type (size) for bitflags.
     /// If no fields use this enum, the bitmask is true, but primitive is None. In this case
     /// regular enum is generated as primitive is unknown.
-    pub primitive: Option<String>,
+    pub primitive: Option<MavType>,
     pub bitmask: bool,
     pub deprecated: Option<MavDeprecation>,
     pub additional_primives: HashSet<MavType>,
@@ -552,7 +572,11 @@ impl MavEnum {
         }
     }
 
-    fn emit_defs(&self, max_value: u64) -> Vec<TokenStream> {
+    fn emit_defs(&self, restricted_primitive: Option<&MavType>) -> Vec<TokenStream> {
+        let max_value = restricted_primitive
+            .as_ref()
+            .map(|t| t.max_int_value())
+            .unwrap_or(u64::MAX);
         let mut cnt = 0u64;
         self.entries
             .iter()
@@ -603,12 +627,12 @@ impl MavEnum {
     }
 
     #[inline(always)]
-    fn emit_name(&self, additional_primitive: Option<MavType>) -> TokenStream {
+    fn emit_name(&self, additional_primitive: Option<&MavType>) -> TokenStream {
         let name = format_ident!(
             "{}{}",
             self.name,
             &additional_primitive
-                .map(|s| s.primitive_type().to_uppercase())
+                .map(|s| s.rust_primitive_type().to_uppercase())
                 .unwrap_or_default()
         );
         quote!(#name)
@@ -638,23 +662,27 @@ impl MavEnum {
     }
 
     fn emit_enum_def(&self, restricted_primitive: Option<MavType>) -> TokenStream {
-        let defs = self.emit_defs(
-            restricted_primitive
-                .as_ref()
-                .map(|t| t.max_int_value())
-                .unwrap_or(u64::MAX),
-        );
-        let enum_name = self.emit_name(restricted_primitive);
+        let defs = self.emit_defs(restricted_primitive.as_ref());
+        let enum_name = self.emit_name(restricted_primitive.as_ref());
         let const_default = self.emit_const_default();
 
         let deprecated = self.emit_deprecation();
 
-        let description = if let Some(description) = self.description.as_ref() {
+        let mut description = if let Some(description) = self.description.as_ref() {
             let desc = URL_REGEX.replace_all(description, "<$1>");
             quote!(#[doc = #desc])
         } else {
             quote!()
         };
+
+        if let Some(restricted_primitive) = &restricted_primitive {
+            let doc = format!(
+                "This is the `{0}` version of `{1}`. It does not allow flags that exceed `{0}::MAX`",
+                restricted_primitive.rust_primitive_type(),
+                self.emit_name(None),
+            );
+            description.extend(quote! {#[doc = #doc]});
+        }
 
         let mav_bool_impl = if self.name == "MavBool"
             && self
@@ -680,7 +708,13 @@ impl MavEnum {
         };
 
         let enum_def = if let Some(primitive) = self.primitive.clone() {
-            let primitive = format_ident!("{}", primitive);
+            let primitive = format_ident!(
+                "{}",
+                &restricted_primitive
+                    .as_ref()
+                    .unwrap_or(&primitive)
+                    .rust_primitive_type()
+            );
             quote! {
                 bitflags!{
                     #[cfg_attr(feature = "ts-rs", derive(TS))]
@@ -1250,7 +1284,7 @@ impl MavField {
                 if dsp == "bitmask" {
                     // bitflags
                     let tmp = self.mavtype.rust_reader(&quote!(let tmp), buf);
-                    let enum_name_ident = format_ident!("{}", enum_name);
+                    let enum_name_ident = self.emit_type();
                     quote! {
                         #tmp
                         // Keep unknown bits for forward compatibility.
@@ -1281,8 +1315,8 @@ impl MavField {
         if matches!(self.mavtype, MavType::Array(_, _)) {
             let default_value = self.mavtype.emit_default_value(dialect_has_version);
             quote!(#field: #default_value,)
-        } else if let Some(enumname) = &self.enumtype {
-            let ty = TokenStream::from_str(enumname).unwrap();
+        } else if self.enumtype.is_some() {
+            let ty = self.emit_type();
             quote!(#field: #ty::DEFAULT,)
         } else {
             let default_value = self.mavtype.emit_default_value(dialect_has_version);

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -89,7 +89,7 @@ impl MavProfile {
                             for entry in &enm.entries {
                                 if field.mavtype.max_int_value() < entry.value.unwrap_or_default() {
                                     field.is_undersized = true;
-                                    enm.additional_primives.insert(field.mavtype.clone());
+                                    enm.additional_primitives.insert(field.mavtype.clone());
                                     all_fit = false;
                                 } else {
                                     any_fit = true;
@@ -547,7 +547,7 @@ pub struct MavEnum {
     pub primitive: Option<MavType>,
     pub bitmask: bool,
     pub deprecated: Option<MavDeprecation>,
-    pub additional_primives: HashSet<MavType>,
+    pub additional_primitives: HashSet<MavType>,
 }
 
 impl MavEnum {
@@ -567,8 +567,8 @@ impl MavEnum {
                     None => self.entries.push(enum_entry.clone()),
                 }
             }
-            self.additional_primives
-                .extend(enm.additional_primives.clone());
+            self.additional_primitives
+                .extend(enm.additional_primitives.clone());
         }
     }
 
@@ -764,7 +764,7 @@ impl MavEnum {
 
     fn emit_additional_primitives(&self) -> TokenStream {
         let mut ts = TokenStream::new();
-        for primitive in &self.additional_primives {
+        for primitive in &self.additional_primitives {
             ts.extend(self.emit_enum_def(Some(primitive.clone())));
         }
         ts

--- a/mavlink-bindgen/tests/definitions/undersized_bitflag.xml
+++ b/mavlink-bindgen/tests/definitions/undersized_bitflag.xml
@@ -1,0 +1,19 @@
+<mavlink>
+  <enums>
+    <enum name="GIMBAL_DEVICE_CAP_FLAGS" bitmask="true">
+      <entry value="1" name="GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT">
+        <description>Gimbal device supports a retracted position.</description>
+      </entry>
+      <entry value="131072" name="GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL">
+        <description>Gimbal device supports to point to a global latitude, longitude, altitude position.</description>
+      </entry>
+    </enum>
+  </enums>
+  <messages>
+    <message id="283" name="GIMBAL_DEVICE_INFORMATION">
+      <description>Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc..</description>
+      <field type="uint16_t" name="cap_flags" enum="GIMBAL_DEVICE_CAP_FLAGS">Bitmap of gimbal capability flags.</field>
+      <field type="uint32_t" name="cap_flags2" enum="GIMBAL_DEVICE_CAP_FLAGS" invalid="0">Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero.</field>
+    </message>
+  </messages>
+</mavlink>

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -61,3 +61,8 @@ fn snapshot_mav_bool() {
 fn snapshot_mav_cmd() {
     run_snapshot("mav_cmd.xml");
 }
+
+#[test]
+fn snapshot_undersized_bitflag() {
+    run_snapshot("undersized_bitflag.xml");
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@mod.rs.snap
@@ -1,0 +1,14 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+assertion_line: 26
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "dialect-undersized_bitflag")]
+pub mod undersized_bitflag;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
@@ -24,7 +24,7 @@ use num_traits::{FromPrimitive, ToPrimitive};
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "ts-rs")]
 use ts_rs::TS;
-bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlags : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; # [doc = "Gimbal device supports to point to a global latitude, longitude, altitude position."] const GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL = 131072 ; } }
+bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlags : u32 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; # [doc = "Gimbal device supports to point to a global latitude, longitude, altitude position."] const GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL = 131072 ; } }
 impl GimbalDeviceCapFlags {
     pub const DEFAULT: Self = Self::GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT;
 }
@@ -33,11 +33,11 @@ impl Default for GimbalDeviceCapFlags {
         Self::DEFAULT
     }
 }
-bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlagsUINT16_T : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; } }
-impl GimbalDeviceCapFlagsUINT16_T {
+bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] # [doc = "This is the `u16` version of `GimbalDeviceCapFlags`. It does not allow flags that exceed `u16::MAX`"] pub struct GimbalDeviceCapFlagsU16 : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; } }
+impl GimbalDeviceCapFlagsU16 {
     pub const DEFAULT: Self = Self::GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT;
 }
-impl Default for GimbalDeviceCapFlagsUINT16_T {
+impl Default for GimbalDeviceCapFlagsU16 {
     fn default() -> Self {
         Self::DEFAULT
     }
@@ -61,7 +61,7 @@ impl GIMBAL_DEVICE_INFORMATION_DATA {
     pub const ENCODED_LEN: usize = 6usize;
     pub const DEFAULT: Self = Self {
         cap_flags2: GimbalDeviceCapFlags::DEFAULT,
-        cap_flags: GimbalDeviceCapFlags::DEFAULT,
+        cap_flags: GimbalDeviceCapFlagsU16::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
     pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
@@ -101,8 +101,9 @@ impl MessageData for GIMBAL_DEVICE_INFORMATION_DATA {
         __struct.cap_flags2 =
             GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
         let tmp = buf.get_u16_le()?;
-        __struct.cap_flags =
-            GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
+        __struct.cap_flags = GimbalDeviceCapFlagsU16::from_bits_retain(
+            tmp as <GimbalDeviceCapFlagsU16 as Flags>::Bits,
+        );
         Ok(__struct)
     }
     fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
@@ -1,0 +1,219 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+assertion_line: 26
+expression: contents
+---
+#![doc = "MAVLink undersized_bitflag dialect."]
+#![doc = ""]
+#![doc = "This file was automatically generated, do not edit."]
+#![allow(deprecated)]
+#![allow(clippy::match_single_binding)]
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+#[allow(unused_imports)]
+use bitflags::{bitflags, Flags};
+#[allow(unused_imports)]
+use mavlink_core::{
+    bytes::Bytes, bytes_mut::BytesMut, types::CharArray, MavlinkVersion, Message, MessageData,
+};
+#[allow(unused_imports)]
+use num_derive::{FromPrimitive, ToPrimitive};
+#[allow(unused_imports)]
+use num_traits::{FromPrimitive, ToPrimitive};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "ts-rs")]
+use ts_rs::TS;
+bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlags : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; # [doc = "Gimbal device supports to point to a global latitude, longitude, altitude position."] const GIMBAL_DEVICE_CAP_FLAGS_CAN_POINT_LOCATION_GLOBAL = 131072 ; } }
+impl GimbalDeviceCapFlags {
+    pub const DEFAULT: Self = Self::GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT;
+}
+impl Default for GimbalDeviceCapFlags {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+bitflags! { # [cfg_attr (feature = "ts-rs" , derive (TS))] # [cfg_attr (feature = "ts-rs" , ts (export , type = "number"))] # [cfg_attr (feature = "serde" , derive (Serialize , Deserialize))] # [cfg_attr (feature = "arbitrary" , derive (Arbitrary))] # [derive (Debug , Copy , Clone , PartialEq)] pub struct GimbalDeviceCapFlagsUINT16_T : u16 { # [doc = "Gimbal device supports a retracted position."] const GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT = 1 ; } }
+impl GimbalDeviceCapFlagsUINT16_T {
+    pub const DEFAULT: Self = Self::GIMBAL_DEVICE_CAP_FLAGS_HAS_RETRACT;
+}
+impl Default for GimbalDeviceCapFlagsUINT16_T {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+#[doc = "Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc.."]
+#[doc = ""]
+#[doc = "ID: 283"]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "ts-rs", derive(TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+pub struct GIMBAL_DEVICE_INFORMATION_DATA {
+    #[doc = "Extended bitmap of gimbal capability flags (32 bit). For backwards compatibility, the lower 16 bits should also be set in cap_flags. Ground stations should prefer this field if non-zero."]
+    pub cap_flags2: GimbalDeviceCapFlags,
+    #[doc = "Bitmap of gimbal capability flags."]
+    #[doc = "This field can not store all possible values of its associated bitflag enum."]
+    pub cap_flags: GimbalDeviceCapFlagsU16,
+}
+impl GIMBAL_DEVICE_INFORMATION_DATA {
+    pub const ENCODED_LEN: usize = 6usize;
+    pub const DEFAULT: Self = Self {
+        cap_flags2: GimbalDeviceCapFlags::DEFAULT,
+        cap_flags: GimbalDeviceCapFlags::DEFAULT,
+    };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for GIMBAL_DEVICE_INFORMATION_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for GIMBAL_DEVICE_INFORMATION_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 283u32;
+    const NAME: &'static str = "GIMBAL_DEVICE_INFORMATION";
+    const EXTRA_CRC: u8 = 2u8;
+    const ENCODED_LEN: usize = 6usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf;
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        let tmp = buf.get_u32_le()?;
+        __struct.cap_flags2 =
+            GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
+        let tmp = buf.get_u16_le()?;
+        __struct.cap_flags =
+            GimbalDeviceCapFlags::from_bits_retain(tmp as <GimbalDeviceCapFlags as Flags>::Bits);
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_u32_le(self.cap_flags2.bits() as u32);
+        __tmp.put_u16_le(self.cap_flags.bits() as u16);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "ts-rs", derive(TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+#[repr(u32)]
+pub enum MavMessage {
+    #[doc = "Information about a low level gimbal. This message should be requested by the gimbal manager or a ground station using MAV_CMD_REQUEST_MESSAGE. The maximum angles and rates are the limits by hardware. However, the limits by software used are likely different/smaller and dependent on mode/settings/etc.."]
+    #[doc = ""]
+    #[doc = "ID: 283"]
+    GIMBAL_DEVICE_INFORMATION(GIMBAL_DEVICE_INFORMATION_DATA),
+}
+impl MavMessage {
+    pub const fn all_ids() -> &'static [u32] {
+        &[283u32]
+    }
+    pub const fn all_messages() -> &'static [(&'static str, u32)] {
+        &[(
+            GIMBAL_DEVICE_INFORMATION_DATA::NAME,
+            GIMBAL_DEVICE_INFORMATION_DATA::ID,
+        )]
+    }
+}
+impl Message for MavMessage {
+    fn parse(
+        version: MavlinkVersion,
+        id: u32,
+        payload: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        match id {
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => {
+                GIMBAL_DEVICE_INFORMATION_DATA::deser(version, payload)
+                    .map(Self::GIMBAL_DEVICE_INFORMATION)
+            }
+            _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
+        }
+    }
+    fn message_name(&self) -> &'static str {
+        match self {
+            Self::GIMBAL_DEVICE_INFORMATION(..) => GIMBAL_DEVICE_INFORMATION_DATA::NAME,
+        }
+    }
+    fn message_id(&self) -> u32 {
+        match self {
+            Self::GIMBAL_DEVICE_INFORMATION(..) => GIMBAL_DEVICE_INFORMATION_DATA::ID,
+        }
+    }
+    fn message_id_from_name(name: &str) -> Option<u32> {
+        match name {
+            GIMBAL_DEVICE_INFORMATION_DATA::NAME => Some(GIMBAL_DEVICE_INFORMATION_DATA::ID),
+            _ => None,
+        }
+    }
+    fn default_message_from_id(id: u32) -> Option<Self> {
+        match id {
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => Some(Self::GIMBAL_DEVICE_INFORMATION(
+                GIMBAL_DEVICE_INFORMATION_DATA::default(),
+            )),
+            _ => None,
+        }
+    }
+    #[cfg(feature = "arbitrary")]
+    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+        match id {
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => Some(Self::GIMBAL_DEVICE_INFORMATION(
+                GIMBAL_DEVICE_INFORMATION_DATA::random(rng),
+            )),
+            _ => None,
+        }
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        match self {
+            Self::GIMBAL_DEVICE_INFORMATION(body) => body.ser(version, bytes),
+        }
+    }
+    fn extra_crc(id: u32) -> u8 {
+        match id {
+            GIMBAL_DEVICE_INFORMATION_DATA::ID => GIMBAL_DEVICE_INFORMATION_DATA::EXTRA_CRC,
+            _ => 0,
+        }
+    }
+    fn target_system_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+    fn target_component_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
fixes #495
superseeds #496

If a field does not fit any bitflag value an undersized bitflag enum is generated (e.g. `GimbalDeviceCapFlagsU16`), the original bitflag enum is unchanged. The type used for the base enum is determined by the largest possible value.

I didn't add a way to covert between them but that can be manually done via the underlying types when requried.
