### PR TITLE
disable ts-rs feature for docs.rs

### DIFF
--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -100,9 +100,38 @@ format-generated-code = []
 ts-rs = ["dep:ts-rs"]
 
 [package.metadata.docs.rs]
-# Build with all features on docs.rs so that users viewing documentation
+# Build with all features except ts-rs on docs.rs so that users viewing documentation
 # can see everything
-all-features = true
+features = [
+    "default",
+    "mav2-message-extensions",
+    "mav2-message-signing",
+    "embedded",
+    "tokio",
+    "arbitrary",
+
+    "dialect-all",
+    "dialect-ardupilotmega",
+    "dialect-asluav",
+    "dialect-avssuas",
+    "dialect-common",
+    "dialect-csairlink",
+    "dialect-cubepilot",
+    "dialect-development",
+    "dialect-icarous",
+    "dialect-loweheiser",
+    "dialect-marsh",
+    "dialect-matrixpilot",
+    "dialect-minimal",
+    "dialect-paparazzi",
+    "dialect-python_array_test",
+    "dialect-standard",
+    "dialect-stemstudios",
+    "dialect-storm32",
+    "dialect-test",
+    "dialect-ualberta",
+    "dialect-uavionix",
+]
 
 [dev-dependencies]
 tokio = { version = "1.0", default-features = false, features = ["macros", "rt", "time" ] }


### PR DESCRIPTION
Helps #501, `ts-rs` does not generate any docs anyways.

Without the feature the RAM usage is ~2GB less:
without `ts-rs`
```
cargo rustdoc -p mavlink --features serde,format-generated-code,arbitrary,tokio,embedded,std,dialect-all,mav2-message-extensions,mav2-message-signing,dialect-all,dialect-ardupilotmega,dialect-asluav,dialect-avssuas,dialect-common,dialect-csairlink,dialect-cubepilot,dialect-development,dialect-icarous,dialect-loweheiser,dialect-marsh,dialect-matrixpilot,dialect-minimal,dialect-paparazzi,dialect-python_array_test,dialect-standard,dialect-stemstudios,dialect-storm32,dialect-test,dialect-ualberta,dialect-uavionix  -j 1 -- -Z time-passes
 Documenting mavlink v0.18.0 (E:\pv42\rust-mavlink\mavlink)
time:   0.000; rss:   20MB ->   20MB (   +0MB)  parse_crate                                                                                                                                                                                 
time:   0.000; rss:   23MB ->   23MB (   +0MB)  crate_injection                                                                                                                                                                             
time:  29.987; rss:   23MB -> 5841MB (+5817MB)  expand_crate                                                                                                                                                                                
time:  29.987; rss:   23MB -> 5841MB (+5817MB)  macro_expand_crate
time:   0.620; rss: 5841MB -> 5841MB (   +1MB)  AST_validation                                                                                                                                                                              
time:   0.102; rss: 5841MB -> 6033MB ( +192MB)  finalize_imports                                                                                                                                                                            
time:   0.021; rss: 6033MB -> 6039MB (   +6MB)  compute_effective_visibilities                                                                                                                                                              
time:   0.062; rss: 6039MB -> 6039MB (   +0MB)  lint_reexports                                                                                                                                                                              
time:   0.213; rss: 6039MB -> 6011MB (  -28MB)  finalize_macro_resolutions                                                                                                                                                                  
time:   5.522; rss: 6011MB -> 6801MB ( +789MB)  late_resolve_crate                                                                                                                                                                          
time:   0.503; rss: 6801MB -> 6803MB (   +2MB)  resolve_check_unused                                                                                                                                                                        
time:   0.874; rss: 6803MB -> 6803MB (   +0MB)  resolve_postprocess                                                                                                                                                                         
time:   7.297; rss: 5841MB -> 6803MB ( +962MB)  resolve_crate
time:   0.516; rss: 6081MB -> 6081MB (   +0MB)  complete_gated_feature_checking                                                                                                                                                             
time:   2.441; rss: 8679MB -> 5745MB (-2934MB)  drop_ast                                                                                                                                                                                    
time:  23.288; rss: 6081MB -> 6997MB ( +917MB)  wf_checking                                                                                                                                                                                 
time:   1.603; rss: 6997MB -> 7205MB ( +208MB)  module_lints                                                                                                                                                                                
time:   1.603; rss: 6997MB -> 7205MB ( +208MB)  missing_docs
time:   1.471; rss: 7205MB -> 7209MB (   +4MB)  check_mod_attrs                                                                                                                                                                             
time:   0.000; rss: 7209MB -> 7209MB (   +0MB)  unused_lib_feature_checking
time:   0.558; rss: 7228MB -> 7271MB (  +42MB)  clean_crate                                                                                                                                                                                 
time:   2.331; rss: 7271MB -> 7593MB ( +323MB)  collect_synthetic_impls                                                                                                                                                                     
time:   0.020; rss: 7593MB -> 7605MB (  +12MB)  collect_items_for_trait_impls                                                                                                                                                               
time:   3.497; rss: 7271MB -> 7897MB ( +626MB)  collect-trait-impls                                                                                                                                                                         
time:   0.167; rss: 7897MB -> 7897MB (   +0MB)  check_doc_test_visibility                                                                                                                                                                   
time:   0.037; rss: 7897MB -> 7897MB (   +0MB)  strip-aliased-non-local                                                                                                                                                                     
time:   0.000; rss: 7897MB -> 7897MB (   +0MB)  propagate-doc-cfg
time:   0.265; rss: 7897MB -> 7898MB (   +1MB)  strip-hidden                                                                                                                                                                                
time:   0.146; rss: 7898MB -> 7898MB (   +0MB)  strip-private                                                                                                                                                                               
time:   0.083; rss: 7902MB -> 7925MB (  +23MB)  propagate-stability                                                                                                                                                                         
time:   0.142; rss: 7925MB -> 7926MB (   +1MB)  run-lints                                                                                                                                                                                   
time:   0.004; rss: 7926MB -> 7926MB (   +0MB)  check_lint_expectations                                                                                                                                                                     
time:   0.828; rss: 7926MB -> 8116MB ( +190MB)  create_format_cache                                                                                                                                                                         
time:  70.223; rss:   23MB -> 8107MB (+8084MB)  run_global_ctxt                                                                                                                                                                             
time:   8.221; rss: 8107MB -> 8384MB ( +277MB)  create_renderer(html)                                                                                                                                                                       
time:   3.805; rss: 8724MB -> 8081MB ( -643MB)  renderer_after_krate(html)                                                                                                                                                                  
time:  18.406; rss: 8107MB -> 8079MB (  -28MB)  render_html                                                                                                                                                                                 
time:   0.000; rss: 8079MB -> 8079MB (   +0MB)  serialize_dep_graph
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 34s
```
with `ts-rs`
```
cargo rustdoc -p mavlink --features serde,format-generated-code,arbitrary,tokio,embedded,std,dialect-all,mav2-message-extensions,mav2-message-signing,dialect-all,dialect-ardupilotmega,dialect-asluav,dialect-avssuas,dialect-common,dialect-csairlink,dialect-cubepilot,dialect-development,dialect-icarous,dialect-loweheiser,dialect-marsh,dialect-matrixpilot,dialect-minimal,dialect-paparazzi,dialect-python_array_test,dialect-standard,dialect-stemstudios,dialect-storm32,dialect-test,dialect-ualberta,dialect-uavionix,ts-rs  -j 1 -- -Z time-passes
 Documenting mavlink v0.18.0 (E:\pv42\rust-mavlink\mavlink)
time:   0.000; rss:   20MB ->   20MB (   +0MB)  parse_crate                                                                                                                                                                                 
time:   0.000; rss:   23MB ->   23MB (   +0MB)  crate_injection                                                                                                                                                                             
time:  41.729; rss:   23MB -> 7253MB (+7230MB)  expand_crate                                                                                                                                                                                
time:  41.730; rss:   23MB -> 7253MB (+7230MB)  macro_expand_crate
time:   0.801; rss: 7253MB -> 7254MB (   +1MB)  AST_validation                                                                                                                                                                              
time:   0.104; rss: 7254MB -> 7445MB ( +192MB)  finalize_imports                                                                                                                                                                            
time:   0.025; rss: 7445MB -> 7452MB (   +7MB)  compute_effective_visibilities                                                                                                                                                              
time:   0.063; rss: 7452MB -> 7452MB (   +0MB)  lint_reexports                                                                                                                                                                              
time:   0.365; rss: 7452MB -> 7389MB (  -62MB)  finalize_macro_resolutions                                                                                                                                                                  
time:   7.251; rss: 7389MB -> 8742MB (+1352MB)  late_resolve_crate                                                                                                                                                                          
time:   0.700; rss: 8742MB -> 8744MB (   +2MB)  resolve_check_unused                                                                                                                                                                        
time:   1.231; rss: 8744MB -> 8744MB (   +0MB)  resolve_postprocess                                                                                                                                                                         
time:   9.739; rss: 7254MB -> 8744MB (+1490MB)  resolve_crate
time:   0.706; rss: 7970MB -> 7970MB (   +0MB)  complete_gated_feature_checking                                                                                                                                                             
time:   3.423; rss: 11151MB -> 7372MB (-3779MB) drop_ast                                                                                                                                                                                    
time:  31.261; rss: 7970MB -> 8774MB ( +804MB)  wf_checking                                                                                                                                                                                 
time:   1.651; rss: 8774MB -> 9007MB ( +233MB)  module_lints                                                                                                                                                                                
time:   1.651; rss: 8774MB -> 9007MB ( +233MB)  missing_docs                                                                                                                                                                                
time:   1.884; rss: 9007MB -> 9012MB (   +5MB)  check_mod_attrs                                                                                                                                                                             
time:   0.000; rss: 9012MB -> 9012MB (   +0MB)  unused_lib_feature_checking
time:   0.733; rss: 9030MB -> 9074MB (  +44MB)  clean_crate                                                                                                                                                                                 
time:   2.376; rss: 9074MB -> 9379MB ( +305MB)  collect_synthetic_impls                                                                                                                                                                     
time:   0.022; rss: 9379MB -> 9391MB (  +12MB)  collect_items_for_trait_impls                                                                                                                                                               
time:   3.689; rss: 9074MB -> 9739MB ( +665MB)  collect-trait-impls                                                                                                                                                                         
time:   0.183; rss: 9739MB -> 9739MB (   +0MB)  check_doc_test_visibility                                                                                                                                                                   
time:   0.042; rss: 9739MB -> 9739MB (   +0MB)  strip-aliased-non-local                                                                                                                                                                     
time:   0.000; rss: 9739MB -> 9739MB (   +0MB)  propagate-doc-cfg
time:   0.296; rss: 9739MB -> 9741MB (   +1MB)  strip-hidden                                                                                                                                                                                
time:   0.150; rss: 9741MB -> 9741MB (   +0MB)  strip-private                                                                                                                                                                               
time:   0.083; rss: 9743MB -> 9769MB (  +26MB)  propagate-stability                                                                                                                                                                         
time:   0.144; rss: 9769MB -> 9770MB (   +1MB)  run-lints                                                                                                                                                                                   
time:   0.004; rss: 9770MB -> 9770MB (   +0MB)  check_lint_expectations                                                                                                                                                                     
time:   0.983; rss: 9770MB -> 10006MB ( +236MB) create_format_cache                                                                                                                                                                         
time:  93.626; rss:   23MB -> 9997MB (+9974MB)  run_global_ctxt                                                                                                                                                                             
time:  10.082; rss: 9997MB -> 10082MB (  +85MB) create_renderer(html)                                                                                                                                                                       
time:   1.082; rss: 10444MB -> 9935MB ( -509MB) renderer_after_krate(html)                                                                                                                                                                  
time:  20.845; rss: 9997MB -> 9933MB (  -64MB)  render_html                                                                                                                                                                                 
time:   0.000; rss: 9933MB -> 9933MB (   +0MB)  serialize_dep_graph
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 59s                                                                                                                                                                    
   Generated E:\pv42\rust-mavlink\target\doc\mavlink\index.html
```