### PR TITLE
allow rustdoc::broken_intra_doc_links lint in generated code

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -204,6 +204,7 @@ impl MavProfile {
             #comment
             #![allow(deprecated)]
             #![allow(clippy::match_single_binding)]
+            #![allow(rustdoc::broken_intra_doc_links)]
             #[allow(unused_imports)]
             use num_derive::{FromPrimitive, ToPrimitive};
             #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
@@ -8,6 +8,7 @@ expression: contents
 #![doc = "This file was automatically generated, do not edit."]
 #![allow(deprecated)]
 #![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
 #[cfg(feature = "arbitrary")]
 use arbitrary::Arbitrary;
 #[allow(unused_imports)]


### PR DESCRIPTION
Supresses a lot of unresolved link warning on `cargo doc` that trigger on array indices/general square brackets from mavlinks descriptions (e.g. "data[1]"). 
