### PR TITLE
Update rand to 0.10, remove unused bindgen dependencies

### DIFF
--- a/mavlink-bindgen/Cargo.toml
+++ b/mavlink-bindgen/Cargo.toml
@@ -16,7 +16,6 @@ categories.workspace = true
 anstyle = { version = "1.0.11", optional = true }
 anstyle-parse = { version = "1.0.0", optional = true }
 anstyle-query = { version = "1.1.4", optional = true }
-arbitrary = { version = "1.4", optional = true, features = ["derive"] }
 clap = { version = "~4.6.0", optional = true, default-features =false, features = ["derive", "help", "usage", "error-context"] }
 clap_builder = { version = "4.3.24", optional = true}
 clap_lex = { version = "1.0.0", optional = true }
@@ -24,7 +23,6 @@ crc-any = { workspace = true, default-features = false }
 proc-macro2 = "1.0.43"
 quick-xml = "0.40"
 quote = "1"
-rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
 regex = { version = "1.0" }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 thiserror = { version = "2.0.12", default-features = false }
@@ -38,7 +36,8 @@ cli = [
     "dep:anstyle-query",
     "dep:anstyle-parse",
 ]
-arbitrary = ["dep:arbitrary", "dep:rand"]
+# arbitrary and rand dependencies are not needed during codegen 
+arbitrary = []
 mav2-message-extensions = []
 
 [dev-dependencies]

--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -448,7 +448,7 @@ impl MavProfile {
     ) -> TokenStream {
         quote! {
             #[cfg(feature = "arbitrary")]
-            fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+            fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
                 match id {
                     #(#structs::ID => Some(Self::#enums(#structs::random(rng))),)*
                     _ => None,
@@ -1109,7 +1109,7 @@ impl MavMessage {
                 #const_default
 
                 #[cfg(feature = "arbitrary")]
-                pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+                pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
                     use arbitrary::{Unstructured, Arbitrary};
                     let mut buf = [0u8; 1024];
                     rng.fill_bytes(&mut buf);

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__deprecated.xml@deprecated.rs.snap
@@ -94,7 +94,7 @@ impl PING_DATA {
         target_component: 0_u8,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -210,7 +210,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             PING_DATA::ID => Some(Self::PING(PING_DATA::random(rng))),
             _ => None,

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__heartbeat.xml@heartbeat.rs.snap
@@ -58,7 +58,7 @@ impl HEARTBEAT_DATA {
         mavlink_version: MINOR_MAVLINK_VERSION,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -175,7 +175,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             HEARTBEAT_DATA::ID => Some(Self::HEARTBEAT(HEARTBEAT_DATA::random(rng))),
             _ => None,

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_bool.xml@mav_bool.rs.snap
@@ -58,7 +58,7 @@ impl BOOL_TEST_MESSAGE_DATA {
         bool_int8: MavBool::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -175,7 +175,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             BOOL_TEST_MESSAGE_DATA::ID => {
                 Some(Self::BOOL_TEST_MESSAGE(BOOL_TEST_MESSAGE_DATA::random(rng)))

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
@@ -99,7 +99,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             _ => None,
         }

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__no_field_description.xml@no_field_description.rs.snap
@@ -44,7 +44,7 @@ impl CUBEPILOT_RAW_RC_DATA {
         rc_raw: [0_u8; 32usize],
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -162,7 +162,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             CUBEPILOT_RAW_RC_DATA::ID => {
                 Some(Self::CUBEPILOT_RAW_RC(CUBEPILOT_RAW_RC_DATA::random(rng)))

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -84,7 +84,7 @@ impl PARAM_REQUEST_LIST_DATA {
         target_component: 0_u8,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -168,7 +168,7 @@ impl PARAM_REQUEST_READ_DATA {
         param_id: CharArray::new([0_u8; 16usize]),
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -265,7 +265,7 @@ impl PARAM_SET_DATA {
         param_type: MavParamType::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -369,7 +369,7 @@ impl PARAM_VALUE_DATA {
         param_type: MavParamType::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -539,7 +539,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             PARAM_REQUEST_LIST_DATA::ID => Some(Self::PARAM_REQUEST_LIST(
                 PARAM_REQUEST_LIST_DATA::random(rng),

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__superseded.xml@superseded.rs.snap
@@ -129,7 +129,7 @@ impl SMART_BATTERY_INFO_DATA {
         device_name: CharArray::new([0_u8; 50usize]),
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -287,7 +287,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             SMART_BATTERY_INFO_DATA::ID => Some(Self::SMART_BATTERY_INFO(
                 SMART_BATTERY_INFO_DATA::random(rng),

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__undersized_bitflag.xml@undersized_bitflag.rs.snap
@@ -65,7 +65,7 @@ impl GIMBAL_DEVICE_INFORMATION_DATA {
         cap_flags: GimbalDeviceCapFlagsU16::DEFAULT,
     };
     #[cfg(feature = "arbitrary")]
-    pub fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
         use arbitrary::{Arbitrary, Unstructured};
         let mut buf = [0u8; 1024];
         rng.fill_bytes(&mut buf);
@@ -189,7 +189,7 @@ impl Message for MavMessage {
         }
     }
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self> {
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
         match id {
             GIMBAL_DEVICE_INFORMATION_DATA::ID => Some(Self::GIMBAL_DEVICE_INFORMATION(
                 GIMBAL_DEVICE_INFORMATION_DATA::random(rng),

--- a/mavlink-core/Cargo.toml
+++ b/mavlink-core/Cargo.toml
@@ -26,7 +26,7 @@ crc-any = { workspace = true, default-features = false }
 embedded-io = { version = "0.7", optional = true }
 embedded-io-async = { version = "0.7", optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
-rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.10.1", optional = true, default-features = false, features = ["std", "std_rng"] }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2.0", optional = true }
 serialport = { version = "4.7.2", default-features = false, optional = true }

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -213,7 +213,10 @@ where
     fn default_message_from_id(id: u32) -> Option<Self>;
     /// Return random valid message of the speicfied message id
     #[cfg(feature = "arbitrary")]
-    fn random_message_from_id<R: rand::RngCore>(id: u32, rng: &mut R) -> Option<Self>;
+    fn random_message_from_id<R: rand::TryRng<Error = std::convert::Infallible>>(
+        id: u32,
+        rng: &mut R,
+    ) -> Option<Self>;
     /// Return a message types [CRC_EXTRA byte](https://mavlink.io/en/guide/serialization.html#crc_extra)
     fn extra_crc(id: u32) -> u8;
 }

--- a/mavlink/Cargo.toml
+++ b/mavlink/Cargo.toml
@@ -36,7 +36,7 @@ bitflags = { workspace = true }
 serde = { version = "1.0.115", optional = true, features = ["derive"] }
 serde_arrays = { version = "0.2.0", optional = true }
 arbitrary = { version = "1.4", optional = true, features = ["derive"] }
-rand = { version = "0.9", optional = true, default-features = false, features = ["std", "std_rng"] }
+rand = { version = "0.10.1", optional = true, default-features = false, features = ["std", "std_rng"] }
 ts-rs = { version = "11.0.1", optional = true }
 
 [features]


### PR DESCRIPTION
- update to rand [0.10.0](https://github.com/rust-random/rand/releases/tag/0.10.1) and [0.10.1](https://github.com/rust-random/rand/releases/tag/0.10.1)
- renamed `rand::RngCore` to `rand::Rng`
- the `Rng` trait does no longer implement `DerefMut`, but `TryRng<Error = std::convert::Infallible>` does implement both `DerefMut` and `Rng` therefore the change to the `Message` trait.
- the rand and arbitrary deps were not needed in bindgen.