### PR TITLE
update mavlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the crate:
 
 ```toml
 [dependencies]
-mavlink = "0.18.0"
+mavlink = "0.18"
 ```
 
 Simple code example:

--- a/mavlink/examples/mavlink-dump/src/main.rs
+++ b/mavlink/examples/mavlink-dump/src/main.rs
@@ -92,7 +92,7 @@ pub fn request_stream() -> mavlink::dialects::ardupilotmega::MavMessage {
         mavlink::dialects::ardupilotmega::REQUEST_DATA_STREAM_DATA {
             target_system: 0,
             target_component: 0,
-            req_stream_id: 0,
+            req_stream_id: mavlink::dialects::ardupilotmega::MavDataStream::MAV_DATA_STREAM_ALL,
             req_message_rate: 10,
             start_stop: 1,
         },


### PR DESCRIPTION
Updates mavlink submodule to the latest version and fixes https://github.com/mavlink/rust-mavlink/issues/490 with https://github.com/mavlink/mavlink/pull/2498.