### PR TITLE
test dialects dynamically

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,12 +24,22 @@ jobs:
         with:
           args: --all --all-targets --features format-generated-code --features mav2-message-signing --features tokio
 
+  dialect-features:
+    runs-on: ubuntu-latest
+    outputs:
+      features: ${{ steps.features.outputs.features }}
+    steps:
+      - uses: actions/checkout@v6
+        id: features
+        run: echo "features=$(python3 scripts/list_dialect_features.py)" >> "$GITHUB_OUTPUT"
+
   internal-tests:
+    needs: dialect-features
     runs-on: ubuntu-latest
     strategy:
         fail-fast: false
         matrix:
-          dialect: ["dialect-all", "dialect-ardupilotmega", "dialect-asluav", "dialect-matrixpilot", "dialect-minimal", "dialect-paparazzi", "dialect-python_array_test", "dialect-standard", "dialect-test", "dialect-ualberta", "dialect-uavionix", "dialect-icarous", "dialect-common", "dialect-storm32", "dialect-csairlink", "dialect-loweheiser", "dialect-marsh", "dialect-stemstudios"]
+          dialect: ${{ fromJSON(needs.dialect-features.outputs.features) }}
           signing: ["", "--features mav2-message-signing"]
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
       features: ${{ steps.features.outputs.features }}
     steps:
       - uses: actions/checkout@v6
+      - name: List dialect features
         id: features
         run: echo "features=$(python3 scripts/list_dialect_features.py)" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,8 @@ jobs:
       features: ${{ steps.features.outputs.features }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
       - name: List dialect features
         id: features
         run: echo "features=$(python3 scripts/list_dialect_features.py)" >> "$GITHUB_OUTPUT"

--- a/scripts/list_dialect_features.py
+++ b/scripts/list_dialect_features.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+def main():
+    definitions_dir = (
+        Path(__file__).parent.parent
+        / "mavlink"
+        / "mavlink"
+        / "message_definitions"
+        / "v1.0"
+    )
+
+    definitions = sorted(
+        definitions_dir.glob("*.xml"), key=lambda path: path.stem.lower()
+    )
+
+    if not definitions:
+        print(f"No dialect definitions found in {definitions_dir}", file=sys.stderr)
+        return 1
+
+    features = [f"dialect-{definition.stem.lower()}" for definition in definitions]
+    print(json.dumps(features))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
`scripts/list_dialect_features.py` prints all dialect features resolved directly from the submodule and CI uses them to test dialects. If any dialect is missing, the test build will fail with:

    error: none of the selected packages contains this feature: $feature

Fixes https://github.com/mavlink/rust-mavlink/issues/455

