### PR TITLE
fix: decode XML entities in generated rustdoc

### DIFF
--- a/mavlink-bindgen/src/parser.rs
+++ b/mavlink-bindgen/src/parser.rs
@@ -11,7 +11,7 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
-use quick_xml::{Reader, events::Event};
+use quick_xml::{Reader, escape::resolve_xml_entity, events::Event};
 
 use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
@@ -2015,10 +2015,11 @@ pub fn parse_profile(
             }
             Ok(Event::GeneralRef(bytes)) => {
                 let entity = String::from_utf8_lossy(&bytes);
-                text = Some(
-                    text.map(|t| format!("{t}&{entity};"))
-                        .unwrap_or(format!("&{entity};")),
-                );
+                let decoded = resolve_xml_entity(&entity)
+                    .map(str::to_owned)
+                    .unwrap_or_else(|| format!("&{entity};"));
+
+                text = Some(text.map(|t| t + &decoded).unwrap_or(decoded));
             }
             Ok(Event::End(_)) => {
                 match stack.last() {

--- a/mavlink-bindgen/tests/definitions/escaped_html.xml
+++ b/mavlink-bindgen/tests/definitions/escaped_html.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mavlink>
+  <messages>
+    <message id="1" name="ESCAPED_HTML_TEST">
+      <description>Message containing escaped HTML characters.</description>
+      <field type="uint32_t" name="version">
+        Version encoded as: `(Dev &amp; 0xff) &lt;&lt; 24`.
+      </field>
+    </message>
+  </messages>
+</mavlink>

--- a/mavlink-bindgen/tests/e2e_snapshots.rs
+++ b/mavlink-bindgen/tests/e2e_snapshots.rs
@@ -66,3 +66,8 @@ fn snapshot_mav_cmd() {
 fn snapshot_undersized_bitflag() {
     run_snapshot("undersized_bitflag.xml");
 }
+
+#[test]
+fn snapshot_escaped_html() {
+    run_snapshot("escaped_html.xml");
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__escaped_html.xml@escaped_html.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__escaped_html.xml@escaped_html.rs.snap
@@ -1,0 +1,185 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#![doc = "MAVLink escaped_html dialect."]
+#![doc = ""]
+#![doc = "This file was automatically generated, do not edit."]
+#![allow(deprecated)]
+#![allow(clippy::match_single_binding)]
+#![allow(rustdoc::broken_intra_doc_links)]
+#[cfg(feature = "arbitrary")]
+use arbitrary::Arbitrary;
+#[allow(unused_imports)]
+use bitflags::{bitflags, Flags};
+#[allow(unused_imports)]
+use mavlink_core::{
+    bytes::Bytes, bytes_mut::BytesMut, types::CharArray, MavlinkVersion, Message, MessageData,
+};
+#[allow(unused_imports)]
+use num_derive::{FromPrimitive, ToPrimitive};
+#[allow(unused_imports)]
+use num_traits::{FromPrimitive, ToPrimitive};
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+#[cfg(feature = "ts-rs")]
+use ts_rs::TS;
+#[doc = "Message containing escaped HTML characters."]
+#[doc = ""]
+#[doc = "ID: 1"]
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "ts-rs", derive(TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+pub struct ESCAPED_HTML_TEST_DATA {
+    #[doc = "Version encoded as: `(Dev&0xff)<<24`."]
+    pub version: u32,
+}
+impl ESCAPED_HTML_TEST_DATA {
+    pub const ENCODED_LEN: usize = 4usize;
+    pub const DEFAULT: Self = Self { version: 0_u32 };
+    #[cfg(feature = "arbitrary")]
+    pub fn random<R: rand::Rng>(rng: &mut R) -> Self {
+        use arbitrary::{Arbitrary, Unstructured};
+        let mut buf = [0u8; 1024];
+        rng.fill_bytes(&mut buf);
+        let mut unstructured = Unstructured::new(&buf);
+        Self::arbitrary(&mut unstructured).unwrap_or_default()
+    }
+}
+impl Default for ESCAPED_HTML_TEST_DATA {
+    fn default() -> Self {
+        Self::DEFAULT.clone()
+    }
+}
+impl MessageData for ESCAPED_HTML_TEST_DATA {
+    type Message = MavMessage;
+    const ID: u32 = 1u32;
+    const NAME: &'static str = "ESCAPED_HTML_TEST";
+    const EXTRA_CRC: u8 = 161u8;
+    const ENCODED_LEN: usize = 4usize;
+    fn deser(
+        _version: MavlinkVersion,
+        __input: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        let avail_len = __input.len();
+        let mut payload_buf;
+        let mut buf = if avail_len < Self::ENCODED_LEN {
+            payload_buf = [0; Self::ENCODED_LEN];
+            payload_buf[0..avail_len].copy_from_slice(__input);
+            Bytes::new(&payload_buf)
+        } else {
+            Bytes::new(__input)
+        };
+        let mut __struct = Self::default();
+        __struct.version = buf.get_u32_le()?;
+        Ok(__struct)
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        let mut __tmp = BytesMut::new(bytes);
+        if __tmp.remaining() < Self::ENCODED_LEN {
+            panic!(
+                "buffer is too small (need {} bytes, but got {})",
+                Self::ENCODED_LEN,
+                __tmp.remaining(),
+            )
+        }
+        __tmp.put_u32_le(self.version);
+        if matches!(version, MavlinkVersion::V2) {
+            let len = __tmp.len();
+            ::mavlink_core::utils::remove_trailing_zeroes(&bytes[..len])
+        } else {
+            __tmp.len()
+        }
+    }
+}
+#[derive(Clone, PartialEq, Debug)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(tag = "type"))]
+#[cfg_attr(feature = "arbitrary", derive(Arbitrary))]
+#[cfg_attr(feature = "ts-rs", derive(TS))]
+#[cfg_attr(feature = "ts-rs", ts(export))]
+#[repr(u32)]
+pub enum MavMessage {
+    #[doc = "Message containing escaped HTML characters."]
+    #[doc = ""]
+    #[doc = "ID: 1"]
+    ESCAPED_HTML_TEST(ESCAPED_HTML_TEST_DATA),
+}
+impl MavMessage {
+    pub const fn all_ids() -> &'static [u32] {
+        &[1u32]
+    }
+    pub const fn all_messages() -> &'static [(&'static str, u32)] {
+        &[(ESCAPED_HTML_TEST_DATA::NAME, ESCAPED_HTML_TEST_DATA::ID)]
+    }
+}
+impl Message for MavMessage {
+    fn parse(
+        version: MavlinkVersion,
+        id: u32,
+        payload: &[u8],
+    ) -> Result<Self, ::mavlink_core::error::ParserError> {
+        match id {
+            ESCAPED_HTML_TEST_DATA::ID => {
+                ESCAPED_HTML_TEST_DATA::deser(version, payload).map(Self::ESCAPED_HTML_TEST)
+            }
+            _ => Err(::mavlink_core::error::ParserError::UnknownMessage { id }),
+        }
+    }
+    fn message_name(&self) -> &'static str {
+        match self {
+            Self::ESCAPED_HTML_TEST(..) => ESCAPED_HTML_TEST_DATA::NAME,
+        }
+    }
+    fn message_id(&self) -> u32 {
+        match self {
+            Self::ESCAPED_HTML_TEST(..) => ESCAPED_HTML_TEST_DATA::ID,
+        }
+    }
+    fn message_id_from_name(name: &str) -> Option<u32> {
+        match name {
+            ESCAPED_HTML_TEST_DATA::NAME => Some(ESCAPED_HTML_TEST_DATA::ID),
+            _ => None,
+        }
+    }
+    fn default_message_from_id(id: u32) -> Option<Self> {
+        match id {
+            ESCAPED_HTML_TEST_DATA::ID => {
+                Some(Self::ESCAPED_HTML_TEST(ESCAPED_HTML_TEST_DATA::default()))
+            }
+            _ => None,
+        }
+    }
+    #[cfg(feature = "arbitrary")]
+    fn random_message_from_id<R: rand::Rng>(id: u32, rng: &mut R) -> Option<Self> {
+        match id {
+            ESCAPED_HTML_TEST_DATA::ID => {
+                Some(Self::ESCAPED_HTML_TEST(ESCAPED_HTML_TEST_DATA::random(rng)))
+            }
+            _ => None,
+        }
+    }
+    fn ser(&self, version: MavlinkVersion, bytes: &mut [u8]) -> usize {
+        match self {
+            Self::ESCAPED_HTML_TEST(body) => body.ser(version, bytes),
+        }
+    }
+    fn extra_crc(id: u32) -> u8 {
+        match id {
+            ESCAPED_HTML_TEST_DATA::ID => ESCAPED_HTML_TEST_DATA::EXTRA_CRC,
+            _ => 0,
+        }
+    }
+    fn target_system_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+    fn target_component_id(&self) -> Option<u8> {
+        match self {
+            _ => None,
+        }
+    }
+}

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__escaped_html.xml@mod.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__escaped_html.xml@mod.rs.snap
@@ -1,0 +1,13 @@
+---
+source: mavlink-bindgen/tests/e2e_snapshots.rs
+expression: contents
+---
+#[allow(non_camel_case_types)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[allow(clippy::field_reassign_with_default)]
+#[allow(non_snake_case)]
+#[allow(clippy::unnecessary_cast)]
+#[allow(clippy::bad_bit_mask)]
+#[allow(clippy::suspicious_else_formatting)]
+#[cfg(feature = "dialect-escaped_html")]
+pub mod escaped_html;

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__mav_cmd.xml@mav_cmd.rs.snap
@@ -1,6 +1,5 @@
 ---
 source: mavlink-bindgen/tests/e2e_snapshots.rs
-assertion_line: 26
 expression: contents
 ---
 #![doc = "MAVLink mav_cmd dialect."]
@@ -41,7 +40,7 @@ pub enum MavCmd {
     #[doc = "| --------- | ----------- | ------ | ----- |"]
     #[doc = "| 1 (Min Only)| Sample float value. (has a min, unit, label and description)| &ge; 0 | s |"]
     #[doc = "| 2 (UInt)  | Sample value that only allows unsigned ints| 0, 1, .. |  |"]
-    #[doc = "| 3 (Min Max)| This description contains a greater than,&gt;and some text after| -2 .. 255 |  |"]
+    #[doc = "| 3 (Min Max)| This description contains a greater than,>and some text after| -2 .. 255 |  |"]
     #[doc = "| 4 (Enum)  | values are described by an enum| [`MavCmd`] |  |"]
     #[doc = "| 5         |             | Reserved (use 0) |  |"]
     #[doc = "| 6         |             |  |  |"]

--- a/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
+++ b/mavlink-bindgen/tests/snapshots/e2e_snapshots__parameters.xml@parameters.rs.snap
@@ -1,6 +1,5 @@
 ---
 source: mavlink-bindgen/tests/e2e_snapshots.rs
-assertion_line: 26
 expression: contents
 ---
 #![doc = "MAVLink parameters dialect."]
@@ -140,7 +139,7 @@ impl MessageData for PARAM_REQUEST_LIST_DATA {
         }
     }
 }
-#[doc = "Request to read the onboard parameter with the param_id string id. Onboard                 parameters are stored as key[const char*] -&gt;value[float]. This allows to send a                 parameter to any other component (such as the GCS) without the need of previous                 knowledge of possible parameter names. Thus the same GCS can store different                 parameters                 for different autopilots. See also <https://mavlink.io/en/services/parameter.html> for                 a                 full documentation of QGroundControl and IMU code."]
+#[doc = "Request to read the onboard parameter with the param_id string id. Onboard                 parameters are stored as key[const char*] ->value[float]. This allows to send a                 parameter to any other component (such as the GCS) without the need of previous                 knowledge of possible parameter names. Thus the same GCS can store different                 parameters                 for different autopilots. See also <https://mavlink.io/en/services/parameter.html> for                 a                 full documentation of QGroundControl and IMU code."]
 #[doc = ""]
 #[doc = "ID: 20"]
 #[derive(Debug, Clone, PartialEq)]
@@ -454,7 +453,7 @@ pub enum MavMessage {
     #[doc = ""]
     #[doc = "ID: 21"]
     PARAM_REQUEST_LIST(PARAM_REQUEST_LIST_DATA),
-    #[doc = "Request to read the onboard parameter with the param_id string id. Onboard                 parameters are stored as key[const char*] -&gt;value[float]. This allows to send a                 parameter to any other component (such as the GCS) without the need of previous                 knowledge of possible parameter names. Thus the same GCS can store different                 parameters                 for different autopilots. See also <https://mavlink.io/en/services/parameter.html> for                 a                 full documentation of QGroundControl and IMU code."]
+    #[doc = "Request to read the onboard parameter with the param_id string id. Onboard                 parameters are stored as key[const char*] ->value[float]. This allows to send a                 parameter to any other component (such as the GCS) without the need of previous                 knowledge of possible parameter names. Thus the same GCS can store different                 parameters                 for different autopilots. See also <https://mavlink.io/en/services/parameter.html> for                 a                 full documentation of QGroundControl and IMU code."]
     #[doc = ""]
     #[doc = "ID: 20"]
     PARAM_REQUEST_READ(PARAM_REQUEST_READ_DATA),


### PR DESCRIPTION
## What changed

`quick-xml` emits escaped XML entities as `Event::GeneralRef`. The parser was rebuilding those references as literal strings such as `&amp;` and `&lt;`, which meant rustdoc escaped them again in the generated documentation.
This change resolves predefined XML entities while parsing descriptions, so generated docs contain the intended characters.

For example:

```text
(Dev &amp; 0xff) &lt;&lt; 24
```
is now generated as:
```bash
(Dev & 0xff) << 24
```
Unknown entity references are left unchanged.

## Tests
- added a small escaped_html.xml fixture
- added snapshot coverage for &amp; and &lt; inside a Markdown code span
- updated existing snapshots where &gt; and -&gt; are now decoded

## Validation
```bash
cargo test -p mavlink-bindgen
cargo test -p mavlink-bindgen --test e2e_snapshots
cargo fmt --all -- --check
git diff --check
```
Closes #506 .