### PR TITLE
Added socket-backed UDP and TCP configs for caller-provided sockets

### DIFF
--- a/mavlink-core/src/connection/tcp/async.rs
+++ b/mavlink-core/src/connection/tcp/async.rs
@@ -25,6 +25,10 @@ pub async fn tcpout<T: std::net::ToSocketAddrs>(address: T) -> io::Result<AsyncT
 
     let socket = TcpStream::connect(addr).await?;
 
+    connection_from_stream(socket)
+}
+
+fn connection_from_stream(socket: TcpStream) -> io::Result<AsyncTcpConnection> {
     let (reader, writer) = socket.into_split();
 
     Ok(AsyncTcpConnection {
@@ -35,6 +39,11 @@ pub async fn tcpout<T: std::net::ToSocketAddrs>(address: T) -> io::Result<AsyncT
         }),
         state: ConnectionState::new(),
     })
+}
+
+async fn accept(listener: TcpListener) -> io::Result<AsyncTcpConnection> {
+    let (socket, _) = listener.accept().await?;
+    connection_from_stream(socket)
 }
 
 pub async fn tcpin<T: std::net::ToSocketAddrs>(address: T) -> io::Result<AsyncTcpConnection> {
@@ -145,8 +154,20 @@ impl AsyncConnectable for TcpConfig {
         M: Message + Sync + Send,
     {
         let conn = match self.mode {
-            TcpMode::TcpIn => tcpin(&self.address).await,
-            TcpMode::TcpOut => tcpout(&self.address).await,
+            TcpMode::TcpIn => match self.take_listener()? {
+                Some(listener) => {
+                    listener.set_nonblocking(true)?;
+                    accept(TcpListener::from_std(listener)?).await
+                }
+                None => tcpin(&self.address).await,
+            },
+            TcpMode::TcpOut => match self.take_stream()? {
+                Some(stream) => {
+                    stream.set_nonblocking(true)?;
+                    connection_from_stream(TcpStream::from_std(stream)?)
+                }
+                None => tcpout(&self.address).await,
+            },
         };
 
         Ok(Box::new(conn?))

--- a/mavlink-core/src/connection/tcp/config.rs
+++ b/mavlink-core/src/connection/tcp/config.rs
@@ -1,4 +1,7 @@
 use core::fmt::Display;
+use std::io;
+use std::net::{TcpListener, TcpStream};
+use std::sync::{Arc, Mutex};
 
 /// Type of TCP connection
 #[derive(Debug, Clone, Copy)]
@@ -23,12 +26,80 @@ pub enum TcpMode {
 pub struct TcpConfig {
     pub(crate) address: String,
     pub(crate) mode: TcpMode,
+    pub(crate) source: TcpSource,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum TcpSource {
+    Address,
+    Stream(Arc<Mutex<Option<TcpStream>>>),
+    Listener(Arc<Mutex<Option<TcpListener>>>),
 }
 
 impl TcpConfig {
     /// Creates a TCP connection address.
     pub fn new(address: String, mode: TcpMode) -> Self {
-        Self { address, mode }
+        Self {
+            address,
+            mode,
+            source: TcpSource::Address,
+        }
+    }
+
+    /// Creates a TCP client configuration from an already connected stream.
+    ///
+    /// Socket-backed configurations are one-shot, including across clones.
+    pub fn from_stream(stream: TcpStream) -> io::Result<Self> {
+        let address = stream.peer_addr()?.to_string();
+        Ok(Self {
+            address,
+            mode: TcpMode::TcpOut,
+            source: TcpSource::Stream(Arc::new(Mutex::new(Some(stream)))),
+        })
+    }
+
+    /// Creates a TCP server configuration from an already bound listener.
+    ///
+    /// Socket-backed configurations are one-shot, including across clones.
+    pub fn from_listener(listener: TcpListener) -> io::Result<Self> {
+        let address = listener.local_addr()?.to_string();
+        Ok(Self {
+            address,
+            mode: TcpMode::TcpIn,
+            source: TcpSource::Listener(Arc::new(Mutex::new(Some(listener)))),
+        })
+    }
+
+    pub(crate) fn take_stream(&self) -> io::Result<Option<TcpStream>> {
+        match &self.source {
+            TcpSource::Address => Ok(None),
+            TcpSource::Stream(stream) => stream
+                .lock()
+                .map_err(|_| io::Error::other("TCP stream lock poisoned"))?
+                .take()
+                .map(Some)
+                .ok_or_else(|| io::Error::other("TCP socket-backed configuration already used")),
+            TcpSource::Listener(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TCP listener cannot be used as an outgoing connection",
+            )),
+        }
+    }
+
+    pub(crate) fn take_listener(&self) -> io::Result<Option<TcpListener>> {
+        match &self.source {
+            TcpSource::Address => Ok(None),
+            TcpSource::Listener(listener) => listener
+                .lock()
+                .map_err(|_| io::Error::other("TCP listener lock poisoned"))?
+                .take()
+                .map(Some)
+                .ok_or_else(|| io::Error::other("TCP socket-backed configuration already used")),
+            TcpSource::Stream(_) => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "TCP stream cannot be used as an incoming connection",
+            )),
+        }
     }
 }
 impl Display for TcpConfig {

--- a/mavlink-core/src/connection/tcp/sync.rs
+++ b/mavlink-core/src/connection/tcp/sync.rs
@@ -28,6 +28,10 @@ pub fn tcpout<T: ToSocketAddrs>(address: T) -> io::Result<TcpConnection> {
     let socket = TcpStream::connect(addr)?;
     socket.set_read_timeout(Some(Duration::from_millis(100)))?;
 
+    connection_from_stream(socket)
+}
+
+fn connection_from_stream(socket: TcpStream) -> io::Result<TcpConnection> {
     Ok(TcpConnection {
         reader: Mutex::new(PeekReader::new(socket.try_clone()?)),
         writer: Mutex::new(TcpWrite {
@@ -59,6 +63,19 @@ pub fn tcpin<T: ToSocketAddrs>(address: T) -> io::Result<TcpConnection> {
                 //TODO don't println in lib
                 println!("listener err: {e}");
             }
+        }
+    }
+    Err(io::Error::new(
+        io::ErrorKind::NotConnected,
+        "No incoming connections!",
+    ))
+}
+
+fn accept(listener: TcpListener) -> io::Result<TcpConnection> {
+    for incoming in listener.incoming() {
+        match incoming {
+            Ok(socket) => return connection_from_stream(socket),
+            Err(e) => println!("listener err: {e}"),
         }
     }
     Err(io::Error::new(
@@ -137,8 +154,14 @@ impl<M: Message> MavConnection<M> for TcpConnection {
 impl Connectable for TcpConfig {
     fn connect<M: Message>(&self) -> io::Result<Connection<M>> {
         let conn = match self.mode {
-            TcpMode::TcpIn => tcpin(&self.address),
-            TcpMode::TcpOut => tcpout(&self.address),
+            TcpMode::TcpIn => match self.take_listener()? {
+                Some(listener) => accept(listener),
+                None => tcpin(&self.address),
+            },
+            TcpMode::TcpOut => match self.take_stream()? {
+                Some(stream) => connection_from_stream(stream),
+                None => tcpout(&self.address),
+            },
         };
 
         Ok(conn?.into())

--- a/mavlink-core/src/connection/udp/async.rs
+++ b/mavlink-core/src/connection/udp/async.rs
@@ -72,6 +72,7 @@ impl AsyncRead for UdpRead {
 struct UdpWrite {
     socket: Arc<UdpSocket>,
     dest: Option<std::net::SocketAddr>,
+    connected: bool,
     sequence: u8,
 }
 
@@ -84,7 +85,12 @@ impl AsyncWrite for UdpWrite {
         let this = self.get_mut();
         let addr = this.dest.expect("`dest` is checked before write");
 
-        match this.socket.poll_send_to(cx, buf, addr) {
+        let result = if this.connected {
+            this.socket.poll_send(cx, buf)
+        } else {
+            this.socket.poll_send_to(cx, buf, addr)
+        };
+        match result {
             Poll::Ready(Ok(written)) if written == buf.len() => Poll::Ready(Ok(written)),
             Poll::Ready(Ok(_)) => Poll::Ready(Err(io::Error::new(
                 io::ErrorKind::WriteZero,
@@ -122,6 +128,7 @@ impl AsyncUdpConnection {
         socket: UdpSocket,
         server: bool,
         dest: Option<std::net::SocketAddr>,
+        connected: bool,
     ) -> io::Result<Self> {
         let socket = Arc::new(socket);
         Ok(Self {
@@ -134,6 +141,7 @@ impl AsyncUdpConnection {
             writer: Mutex::new(UdpWrite {
                 socket,
                 dest,
+                connected,
                 sequence: 0,
             }),
             state: ConnectionState::new(),
@@ -248,11 +256,19 @@ impl AsyncConnectable for UdpConfig {
             UdpMode::Udpin => (&self.address, true, None),
             _ => ("0.0.0.0:0", false, Some(get_socket_addr(&self.address)?)),
         };
-        let socket = UdpSocket::bind(addr).await?;
+        let (socket, connected) = match self.take_socket()? {
+            Some(socket) => {
+                socket.set_nonblocking(true)?;
+                (UdpSocket::from_std(socket)?, !server)
+            }
+            None => (UdpSocket::bind(addr).await?, false),
+        };
         if matches!(self.mode, UdpMode::UdpBroadcast) {
             socket.set_broadcast(true)?;
         }
-        Ok(Box::new(AsyncUdpConnection::new(socket, server, dest)?))
+        Ok(Box::new(AsyncUdpConnection::new(
+            socket, server, dest, connected,
+        )?))
     }
 }
 

--- a/mavlink-core/src/connection/udp/config.rs
+++ b/mavlink-core/src/connection/udp/config.rs
@@ -1,4 +1,7 @@
 use core::fmt::Display;
+use std::io;
+use std::net::UdpSocket;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 /// Type of UDP connection
@@ -29,6 +32,13 @@ pub struct UdpConfig {
     pub(crate) address: String,
     pub(crate) mode: UdpMode,
     pub(crate) read_timeout: Option<Duration>,
+    pub(crate) source: UdpSource,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum UdpSource {
+    Address,
+    Socket(Arc<Mutex<Option<UdpSocket>>>),
 }
 
 impl UdpConfig {
@@ -40,6 +50,38 @@ impl UdpConfig {
             address,
             mode,
             read_timeout: None,
+            source: UdpSource::Address,
+        }
+    }
+
+    /// Creates a UDP configuration from an existing socket.
+    ///
+    /// Input sockets must be bound. Output and broadcast sockets must also be
+    /// connected; their peer address is used as the destination. Socket-backed
+    /// configurations are one-shot, including across cloned configurations.
+    pub fn from_socket(socket: UdpSocket, mode: UdpMode) -> io::Result<Self> {
+        let address = match mode {
+            UdpMode::Udpin => socket.local_addr()?,
+            UdpMode::Udpout | UdpMode::UdpBroadcast => socket.peer_addr()?,
+        };
+
+        Ok(Self {
+            address: address.to_string(),
+            mode,
+            read_timeout: None,
+            source: UdpSource::Socket(Arc::new(Mutex::new(Some(socket)))),
+        })
+    }
+
+    pub(crate) fn take_socket(&self) -> io::Result<Option<UdpSocket>> {
+        match &self.source {
+            UdpSource::Address => Ok(None),
+            UdpSource::Socket(socket) => socket
+                .lock()
+                .map_err(|_| io::Error::other("UDP socket lock poisoned"))?
+                .take()
+                .map(Some)
+                .ok_or_else(|| io::Error::other("UDP socket-backed configuration already used")),
         }
     }
 

--- a/mavlink-core/src/connection/udp/sync.rs
+++ b/mavlink-core/src/connection/udp/sync.rs
@@ -47,13 +47,18 @@ impl Read for UdpRead {
 struct UdpWrite {
     socket: UdpSocket,
     dest: Option<SocketAddr>,
+    connected: bool,
     sequence: u8,
 }
 
 impl Write for UdpWrite {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         let addr = self.dest.expect("`dest` is checked before write");
-        self.socket.send_to(buf, addr)
+        if self.connected {
+            self.socket.send(buf)
+        } else {
+            self.socket.send_to(buf, addr)
+        }
     }
 
     fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
@@ -80,7 +85,12 @@ pub struct UdpConnection {
 }
 
 impl UdpConnection {
-    fn new(socket: UdpSocket, server: bool, dest: Option<SocketAddr>) -> io::Result<Self> {
+    fn new(
+        socket: UdpSocket,
+        server: bool,
+        dest: Option<SocketAddr>,
+        connected: bool,
+    ) -> io::Result<Self> {
         Ok(Self {
             server,
             reader: Mutex::new(PeekReader::new(UdpRead {
@@ -91,6 +101,7 @@ impl UdpConnection {
             writer: Mutex::new(UdpWrite {
                 socket,
                 dest,
+                connected,
                 sequence: 0,
             }),
             state: ConnectionState::new(),
@@ -191,14 +202,17 @@ impl Connectable for UdpConfig {
             UdpMode::Udpin => (&self.address, true, None),
             _ => ("0.0.0.0:0", false, Some(get_socket_addr(&self.address)?)),
         };
-        let socket = UdpSocket::bind(addr)?;
+        let (socket, connected) = match self.take_socket()? {
+            Some(socket) => (socket, !server),
+            None => (UdpSocket::bind(addr)?, false),
+        };
         if let Some(timeout) = self.read_timeout {
             socket.set_read_timeout(Some(timeout))?;
         }
         if matches!(self.mode, UdpMode::UdpBroadcast) {
             socket.set_broadcast(true)?;
         }
-        Ok(UdpConnection::new(socket, server, dest)?.into())
+        Ok(UdpConnection::new(socket, server, dest, connected)?.into())
     }
 }
 

--- a/mavlink/tests/socket_config_tests.rs
+++ b/mavlink/tests/socket_config_tests.rs
@@ -1,0 +1,133 @@
+mod test_shared;
+
+#[cfg(all(
+    feature = "std",
+    feature = "dialect-common",
+    feature = "transport-udp",
+    feature = "transport-tcp"
+))]
+mod socket_configs {
+    use std::net::{TcpListener, TcpStream, UdpSocket};
+    use std::time::Duration;
+
+    use mavlink::dialects::common::MavMessage;
+    use mavlink::{Connectable, MavConnection, TcpConfig, UdpConfig, UdpMode};
+
+    fn heartbeat() -> MavMessage {
+        MavMessage::HEARTBEAT(crate::test_shared::get_heartbeat_msg())
+    }
+
+    #[test]
+    fn supplied_udp_sockets_exchange_messages_and_are_one_shot() {
+        let input = UdpSocket::bind("127.0.0.1:0").unwrap();
+        input
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let input_address = input.local_addr().unwrap();
+        let input_config = UdpConfig::from_socket(input, UdpMode::Udpin).unwrap();
+        assert_eq!(input_config.to_string(), format!("udpin:{input_address}"));
+
+        let output = UdpSocket::bind("127.0.0.1:0").unwrap();
+        output.connect(input_address).unwrap();
+        let output_config = UdpConfig::from_socket(output, UdpMode::Udpout).unwrap();
+
+        let receiver = input_config.connect::<MavMessage>().unwrap();
+        let sender = output_config.connect::<MavMessage>().unwrap();
+        sender.send_default(&heartbeat()).unwrap();
+        assert!(matches!(
+            receiver.recv().unwrap().1,
+            MavMessage::HEARTBEAT(_)
+        ));
+
+        assert!(input_config.connect::<MavMessage>().is_err());
+        assert!(output_config.connect::<MavMessage>().is_err());
+    }
+
+    #[test]
+    fn supplied_udp_broadcast_requires_a_peer_and_enables_broadcast() {
+        let unconnected = UdpSocket::bind("127.0.0.1:0").unwrap();
+        assert!(UdpConfig::from_socket(unconnected, UdpMode::UdpBroadcast).is_err());
+
+        let socket = UdpSocket::bind("0.0.0.0:0").unwrap();
+        socket.set_broadcast(true).unwrap();
+        socket.connect("255.255.255.255:14550").unwrap();
+        socket.set_broadcast(false).unwrap();
+        let check = socket.try_clone().unwrap();
+        let config = UdpConfig::from_socket(socket, UdpMode::UdpBroadcast).unwrap();
+        let _connection = config.connect::<MavMessage>().unwrap();
+        assert!(check.broadcast().unwrap());
+    }
+
+    #[test]
+    fn supplied_tcp_listener_and_stream_exchange_messages_and_are_one_shot() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_config = TcpConfig::from_listener(listener).unwrap();
+        assert_eq!(server_config.to_string(), format!("tcpin:{address}"));
+
+        let server_config_for_thread = server_config.clone();
+        let server =
+            std::thread::spawn(move || server_config_for_thread.connect::<MavMessage>().unwrap());
+        let stream = TcpStream::connect(address).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let client_config = TcpConfig::from_stream(stream).unwrap();
+        let client = client_config.connect::<MavMessage>().unwrap();
+        let server = server.join().unwrap();
+
+        client.send_default(&heartbeat()).unwrap();
+        assert!(matches!(server.recv().unwrap().1, MavMessage::HEARTBEAT(_)));
+        assert!(server_config.connect::<MavMessage>().is_err());
+        assert!(client_config.connect::<MavMessage>().is_err());
+    }
+
+    #[cfg(feature = "tokio")]
+    mod asynchronous {
+        use super::*;
+        use mavlink::AsyncConnectable;
+
+        #[tokio::test]
+        async fn supplied_udp_sockets_work_async() {
+            let input = UdpSocket::bind("127.0.0.1:0").unwrap();
+            let address = input.local_addr().unwrap();
+            let output = UdpSocket::bind("127.0.0.1:0").unwrap();
+            output.connect(address).unwrap();
+
+            let input_config = UdpConfig::from_socket(input, UdpMode::Udpin).unwrap();
+            let output_config = UdpConfig::from_socket(output, UdpMode::Udpout).unwrap();
+            let receiver = input_config.connect_async::<MavMessage>().await.unwrap();
+            let sender = output_config.connect_async::<MavMessage>().await.unwrap();
+            sender.send_default(&heartbeat()).await.unwrap();
+            let received = tokio::time::timeout(Duration::from_secs(2), receiver.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(matches!(received.1, MavMessage::HEARTBEAT(_)));
+            assert!(input_config.connect_async::<MavMessage>().await.is_err());
+        }
+
+        #[tokio::test]
+        async fn supplied_tcp_listener_and_stream_work_async() {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let address = listener.local_addr().unwrap();
+            let server_config = TcpConfig::from_listener(listener).unwrap();
+            let stream = TcpStream::connect(address).unwrap();
+            let client_config = TcpConfig::from_stream(stream).unwrap();
+
+            let (server, client) = tokio::join!(
+                server_config.connect_async::<MavMessage>(),
+                client_config.connect_async::<MavMessage>()
+            );
+            let server = server.unwrap();
+            let client = client.unwrap();
+            client.send_default(&heartbeat()).await.unwrap();
+            let received = tokio::time::timeout(Duration::from_secs(2), server.recv())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(matches!(received.1, MavMessage::HEARTBEAT(_)));
+            assert!(client_config.connect_async::<MavMessage>().await.is_err());
+        }
+    }
+}


### PR DESCRIPTION
Allow UDP and TCP configurations to use outside sockets.

Added:
- UdpConfig::from_socket
- TcpConfig::from_stream
- TcpConfig::from_listener

Note:
I had previously started this and finally had the time to finish:
Original pr: https://github.com/mavlink/rust-mavlink/pull/438


