### PR TITLE
Added a new method to recv including unknown messages

### DIFF
--- a/mavlink-core/src/connection/async.rs
+++ b/mavlink-core/src/connection/async.rs
@@ -24,6 +24,14 @@ pub trait AsyncMavConnection<M: Message + Sync + Send> {
     /// Yield until a valid frame is received, ignoring invalid messages.
     async fn recv_raw(&self) -> Result<MAVLinkMessageRaw, MessageReadError>;
 
+    /// Receive a raw MAVLink message, including messages whose ID is unknown to `M`.
+    ///
+    /// Unknown messages are returned without CRC validation because their
+    /// dialect-specific `CRC_EXTRA` is unavailable.
+    async fn recv_raw_including_unknown(&self) -> Result<MAVLinkMessageRaw, MessageReadError> {
+        self.recv_raw().await
+    }
+
     /// Try to receive a MAVLink message.
     ///
     /// Non-blocking variant of `recv()`, returns immediately with a `MessageReadError`

--- a/mavlink-core/src/connection/direct_serial/async.rs
+++ b/mavlink-core/src/connection/direct_serial/async.rs
@@ -14,7 +14,7 @@ use crate::connection::AsyncConnectable;
 use crate::connection::direct_serial::config::SerialConfig;
 use crate::connection_shared::{
     ConnectionState, next_atomic_send_header, read_message_async, read_raw_message_async,
-    write_message_async, write_raw_message_async,
+    read_raw_message_async_including_unknown, write_message_async, write_raw_message_async,
 };
 use crate::error::MessageReadError;
 use crate::{MavHeader, MavlinkVersion, Message, async_peek_reader::AsyncPeekReader};
@@ -53,6 +53,24 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncSerialConnection {
             let result = read_raw_message_async::<M, _>(port.deref_mut(), &self.state).await;
             match result {
                 Ok(message) => return Ok(message),
+                Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    return Err(MessageReadError::Io(e));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut port = self.read_port.lock().await;
+        loop {
+            let result =
+                read_raw_message_async_including_unknown::<M, _>(port.deref_mut(), &self.state)
+                    .await;
+            match result {
+                ok @ Ok(..) => return ok,
                 Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
                     return Err(MessageReadError::Io(e));
                 }

--- a/mavlink-core/src/connection/direct_serial/sync.rs
+++ b/mavlink-core/src/connection/direct_serial/sync.rs
@@ -3,8 +3,8 @@
 use crate::Connectable;
 use crate::connection::{Connection, MavConnection};
 use crate::connection_shared::{
-    ConnectionState, next_atomic_send_header, read_message, read_raw_message, write_message,
-    write_raw_message,
+    ConnectionState, next_atomic_send_header, read_message, read_raw_message,
+    read_raw_message_including_unknown, write_message, write_raw_message,
 };
 use crate::error::{MessageReadError, MessageWriteError};
 use crate::peek_reader::PeekReader;
@@ -58,6 +58,21 @@ impl<M: Message> MavConnection<M> for SerialConnection {
                 ok @ Ok(..) => {
                     return ok;
                 }
+                Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    return Err(MessageReadError::Io(e));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn recv_raw_including_unknown(&self) -> Result<MAVLinkMessageRaw, MessageReadError> {
+        let mut port = self.read_port.lock().unwrap();
+
+        loop {
+            let result = read_raw_message_including_unknown::<M, _>(port.deref_mut(), &self.state);
+            match result {
+                ok @ Ok(..) => return ok,
                 Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
                     return Err(MessageReadError::Io(e));
                 }

--- a/mavlink-core/src/connection/file/async.rs
+++ b/mavlink-core/src/connection/file/async.rs
@@ -5,7 +5,10 @@ use std::path::PathBuf;
 
 use crate::connection::file::config::FileConfig;
 use crate::connection::{AsyncConnectable, AsyncMavConnection};
-use crate::connection_shared::{ConnectionState, read_message_async, read_raw_message_async};
+use crate::connection_shared::{
+    ConnectionState, read_message_async, read_raw_message_async,
+    read_raw_message_async_including_unknown,
+};
 use crate::error::{MessageReadError, MessageWriteError};
 use crate::{
     MAVLinkMessageRaw, MavHeader, MavlinkVersion, Message, async_peek_reader::AsyncPeekReader,
@@ -41,6 +44,24 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncFileConnection {
                 ok @ Ok(..) => {
                     return ok;
                 }
+                Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    return Err(MessageReadError::Io(e));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut file = self.file.lock().await;
+        loop {
+            let result =
+                read_raw_message_async_including_unknown::<M, _>(file.deref_mut(), &self.state)
+                    .await;
+            match result {
+                ok @ Ok(..) => return ok,
                 Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
                     return Err(MessageReadError::Io(e));
                 }

--- a/mavlink-core/src/connection/file/sync.rs
+++ b/mavlink-core/src/connection/file/sync.rs
@@ -1,7 +1,9 @@
 //! File MAVLINK connection
 
 use crate::connection::{Connection, MavConnection};
-use crate::connection_shared::{ConnectionState, read_message, read_raw_message};
+use crate::connection_shared::{
+    ConnectionState, read_message, read_raw_message, read_raw_message_including_unknown,
+};
 use crate::error::{MessageReadError, MessageWriteError};
 use crate::peek_reader::PeekReader;
 use crate::{Connectable, MAVLinkMessageRaw};
@@ -58,6 +60,23 @@ impl<M: Message> MavConnection<M> for FileConnection {
                 ok @ Ok(..) => {
                     return ok;
                 }
+                Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
+                    return Err(MessageReadError::Io(e));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut file = self.file.lock().unwrap();
+
+        loop {
+            let result = read_raw_message_including_unknown::<M, _>(file.deref_mut(), &self.state);
+            match result {
+                ok @ Ok(..) => return ok,
                 Err(MessageReadError::Io(e)) if e.kind() == io::ErrorKind::UnexpectedEof => {
                     return Err(MessageReadError::Io(e));
                 }

--- a/mavlink-core/src/connection/sync.rs
+++ b/mavlink-core/src/connection/sync.rs
@@ -44,6 +44,14 @@ pub trait MavConnection<M: Message> {
     /// return any errors, otherwise return any errors that occured while receiving.
     fn recv_raw(&self) -> Result<MAVLinkMessageRaw, MessageReadError>;
 
+    /// Receive a raw MAVLink message, including messages whose ID is unknown to `M`.
+    ///
+    /// Unknown messages are returned without CRC validation because their
+    /// dialect-specific `CRC_EXTRA` is unavailable.
+    fn recv_raw_including_unknown(&self) -> Result<MAVLinkMessageRaw, MessageReadError> {
+        self.recv_raw()
+    }
+
     /// Try to receive a MAVLink message.
     ///
     /// Non-blocking variant of `recv()`, returns immediately with a `MessageReadError`
@@ -194,6 +202,26 @@ impl<M: Message> MavConnection<M> for Connection<M> {
             #[cfg(feature = "transport-direct-serial")]
             ConnectionInner::Serial(conn) => <SerialConnection as MavConnection<M>>::recv_raw(conn),
             ConnectionInner::File(conn) => <FileConnection as MavConnection<M>>::recv_raw(conn),
+        }
+    }
+
+    fn recv_raw_including_unknown(&self) -> Result<MAVLinkMessageRaw, MessageReadError> {
+        match &self.inner {
+            #[cfg(feature = "transport-tcp")]
+            ConnectionInner::Tcp(conn) => {
+                <TcpConnection as MavConnection<M>>::recv_raw_including_unknown(conn)
+            }
+            #[cfg(feature = "transport-udp")]
+            ConnectionInner::Udp(conn) => {
+                <UdpConnection as MavConnection<M>>::recv_raw_including_unknown(conn)
+            }
+            #[cfg(feature = "transport-direct-serial")]
+            ConnectionInner::Serial(conn) => {
+                <SerialConnection as MavConnection<M>>::recv_raw_including_unknown(conn)
+            }
+            ConnectionInner::File(conn) => {
+                <FileConnection as MavConnection<M>>::recv_raw_including_unknown(conn)
+            }
         }
     }
 

--- a/mavlink-core/src/connection/tcp/async.rs
+++ b/mavlink-core/src/connection/tcp/async.rs
@@ -7,7 +7,7 @@ use crate::connection::tcp::config::{TcpConfig, TcpMode};
 use crate::connection::{AsyncConnectable, AsyncMavConnection, get_socket_addr};
 use crate::connection_shared::{
     ConnectionState, next_send_header, read_message_async, read_raw_message_async,
-    write_message_async, write_raw_message_async,
+    read_raw_message_async_including_unknown, write_message_async, write_raw_message_async,
 };
 use crate::{MAVLinkMessageRaw, MavHeader, MavlinkVersion, Message};
 
@@ -86,6 +86,13 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncTcpConnection {
     async fn recv_raw(&self) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
         let mut reader = self.reader.lock().await;
         read_raw_message_async::<M, _>(reader.deref_mut(), &self.state).await
+    }
+
+    async fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().await;
+        read_raw_message_async_including_unknown::<M, _>(reader.deref_mut(), &self.state).await
     }
 
     async fn try_recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {

--- a/mavlink-core/src/connection/tcp/sync.rs
+++ b/mavlink-core/src/connection/tcp/sync.rs
@@ -5,8 +5,8 @@ use crate::MAVLinkMessageRaw;
 use crate::connection::get_socket_addr;
 use crate::connection::{Connection, MavConnection};
 use crate::connection_shared::{
-    ConnectionState, next_send_header, read_message, read_raw_message, write_message,
-    write_raw_message,
+    ConnectionState, next_send_header, read_message, read_raw_message,
+    read_raw_message_including_unknown, write_message, write_raw_message,
 };
 use crate::peek_reader::PeekReader;
 use crate::{MavHeader, MavlinkVersion, Message};
@@ -87,6 +87,13 @@ impl<M: Message> MavConnection<M> for TcpConnection {
     fn recv_raw(&self) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
         let mut reader = self.reader.lock().unwrap();
         read_raw_message::<M, _>(reader.deref_mut(), &self.state)
+    }
+
+    fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().unwrap();
+        read_raw_message_including_unknown::<M, _>(reader.deref_mut(), &self.state)
     }
 
     fn try_recv(&self) -> Result<(MavHeader, M), crate::error::MessageReadError> {

--- a/mavlink-core/src/connection/udp/async.rs
+++ b/mavlink-core/src/connection/udp/async.rs
@@ -15,7 +15,7 @@ use crate::MAVLinkMessageRaw;
 use crate::connection::udp::config::{UdpConfig, UdpMode};
 use crate::connection_shared::{
     ConnectionState, next_send_header, read_message_async, read_raw_message_async,
-    write_message_async, write_raw_message_async,
+    read_raw_message_async_including_unknown, write_message_async, write_raw_message_async,
 };
 use crate::{MavHeader, MavlinkVersion, Message, async_peek_reader::AsyncPeekReader};
 
@@ -166,6 +166,21 @@ impl<M: Message + Sync + Send> AsyncMavConnection<M> for AsyncUdpConnection {
         let mut reader = self.reader.lock().await;
         loop {
             let result = read_raw_message_async::<M, _>(reader.deref_mut(), &self.state).await;
+            self.update_reply_destination(reader.deref_mut()).await;
+            if let ok @ Ok(..) = result {
+                return ok;
+            }
+        }
+    }
+
+    async fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().await;
+        loop {
+            let result =
+                read_raw_message_async_including_unknown::<M, _>(reader.deref_mut(), &self.state)
+                    .await;
             self.update_reply_destination(reader.deref_mut()).await;
             if let ok @ Ok(..) = result {
                 return ok;

--- a/mavlink-core/src/connection/udp/sync.rs
+++ b/mavlink-core/src/connection/udp/sync.rs
@@ -5,8 +5,8 @@ use crate::MAVLinkMessageRaw;
 use crate::connection::get_socket_addr;
 use crate::connection::{Connection, MavConnection};
 use crate::connection_shared::{
-    ConnectionState, next_send_header, read_message, read_raw_message, write_message,
-    write_raw_message,
+    ConnectionState, next_send_header, read_message, read_raw_message,
+    read_raw_message_including_unknown, write_message, write_raw_message,
 };
 use crate::peek_reader::PeekReader;
 use crate::{MavHeader, MavlinkVersion, Message};
@@ -119,6 +119,16 @@ impl<M: Message> MavConnection<M> for UdpConnection {
         let mut reader = self.reader.lock().unwrap();
 
         let result = read_raw_message::<M, _>(reader.deref_mut(), &self.state);
+        self.update_reply_destination(&reader);
+        result
+    }
+
+    fn recv_raw_including_unknown(
+        &self,
+    ) -> Result<MAVLinkMessageRaw, crate::error::MessageReadError> {
+        let mut reader = self.reader.lock().unwrap();
+
+        let result = read_raw_message_including_unknown::<M, _>(reader.deref_mut(), &self.state);
         self.update_reply_destination(&reader);
         result
     }

--- a/mavlink-core/src/connection_shared.rs
+++ b/mavlink-core/src/connection_shared.rs
@@ -143,6 +143,28 @@ pub(crate) fn read_raw_message<M: Message, R: Read>(
 }
 
 #[cfg(feature = "std")]
+pub(crate) fn read_raw_message_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+    state: &ConnectionState,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    let version = state.read_version();
+
+    #[cfg(not(feature = "mav2-message-signing"))]
+    {
+        crate::read_versioned_raw_message_including_unknown::<M, _>(reader, version)
+    }
+
+    #[cfg(feature = "mav2-message-signing")]
+    {
+        crate::read_versioned_raw_message_signed_including_unknown::<M, _>(
+            reader,
+            version,
+            state.signing_data(),
+        )
+    }
+}
+
+#[cfg(feature = "std")]
 #[allow(dead_code)]
 pub(crate) fn write_message<M: Message, W: Write>(
     writer: &mut W,
@@ -214,6 +236,29 @@ pub(crate) async fn read_raw_message_async<M: Message, R: AsyncRead + Unpin>(
     #[cfg(feature = "mav2-message-signing")]
     {
         crate::read_versioned_raw_message_async_signed::<M, _>(
+            reader,
+            version,
+            state.signing_data(),
+        )
+        .await
+    }
+}
+
+#[cfg(feature = "tokio")]
+pub(crate) async fn read_raw_message_async_including_unknown<M: Message, R: AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+    state: &ConnectionState,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    let version = state.read_version();
+
+    #[cfg(not(feature = "mav2-message-signing"))]
+    {
+        crate::read_versioned_raw_message_async_including_unknown::<M, _>(reader, version).await
+    }
+
+    #[cfg(feature = "mav2-message-signing")]
+    {
+        crate::read_versioned_raw_message_async_signed_including_unknown::<M, _>(
             reader,
             version,
             state.signing_data(),

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -25,9 +25,10 @@
 //! The `read_*` functions can be used to read a MAVLink message for a [`PeekReader`] wrapping a `[Read]`er.
 //!
 //! They follow the pattern `read_(v1|v2|any|versioned)_(raw_message|msg)[_async][_signed]<M, _>(..)`.
-//! All read functions check for a valid `STX` marker of the corresponding MAVLink version and verify that the message CRC checksum is correct.
+//! All read functions check for a valid `STX` marker of the corresponding MAVLink version. Parsed-message functions verify that the CRC checksum is correct.
+//! Raw-message functions verify CRCs using `M` by default. Their explicitly named `_including_unknown` variants preserve frames with unknown IDs, whose dialect-defined `CRC_EXTRA` value is unavailable.
 //! They attempt to read until either a whole MAVLink message is read or an error occurrs.
-//! While doing so data without STX marker, with an invalid CRC chechsum or invalid signature (if applicable) is discarded.
+//! While doing so data without STX marker, known messages with an invalid CRC checksum, or messages with an invalid signature (if applicable) are discarded.
 //! To determine for which dialect the message CRC should be verified it must be specified
 //! by using the `Message` enum of the dialect as the generic `M`.
 //!
@@ -38,6 +39,7 @@
 //! - `any` functions read messages of either MAVLink version
 //! - `versioned` functions read messages of the version specified in an aditional `version` parameter
 //! - `raw_message` functions return an unparsed message as [`MAVLinkV1MessageRaw`], [`MAVLinkV2MessageRaw`] or [`MAVLinkMessageRaw`]
+//! - `_including_unknown` functions opt into retaining unknown message IDs byte-for-byte for forwarding
 //! - `msg` functions return a parsed message as a tupel of [`MavHeader`] and the `Message` of the specified dialect
 //! - `_async` functions, which are only enabled with the `tokio` feature, are [async](https://doc.rust-lang.org/std/keyword.async.html) and read from an [`AsyncPeekReader`] instead.
 //! - `_signed` functions, which are only enabled with the `mav2-message-signing` feature, have an `Option<&SigningData>` parameter that allows the use of MAVLink 2 message signing.
@@ -215,6 +217,16 @@ where
     ) -> Option<Self>;
     /// Return a message types [CRC_EXTRA byte](https://mavlink.io/en/guide/serialization.html#crc_extra)
     fn extra_crc(id: u32) -> u8;
+}
+
+/// Returns whether `id` is defined by the selected MAVLink dialect.
+///
+/// Unknown messages cannot have their checksum verified because `CRC_EXTRA` is
+/// part of the message definition rather than the wire frame. Raw readers keep
+/// such frames so applications can forward them without understanding them.
+#[inline]
+fn message_id_is_known<M: Message>(id: u32) -> bool {
+    M::default_message_from_id(id).is_some()
 }
 
 pub trait MessageData: Sized {
@@ -455,6 +467,22 @@ pub fn read_versioned_raw_message<M: Message, R: Read>(
     }
 }
 
+/// Read a raw MAVLink message of the specified version, including messages whose ID is unknown to `M`.
+pub fn read_versioned_raw_message_including_unknown<M: Message, R: Read>(
+    r: &mut PeekReader<R>,
+    version: ReadVersion,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    match version {
+        ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
+            read_v2_raw_message_inner::<M, _>(r, None, true)?,
+        )),
+        ReadVersion::Single(MavlinkVersion::V1) => Ok(MAVLinkMessageRaw::V1(
+            read_v1_raw_message_inner::<M, _>(r, true)?,
+        )),
+        ReadVersion::Any => read_any_raw_message_inner::<M, _>(r, None, true),
+    }
+}
+
 /// Asynchronously read and parse a MAVLink message of the specified version from a [`AsyncPeekReader`].
 ///
 /// # Errors
@@ -493,6 +521,26 @@ pub async fn read_versioned_raw_message_async<M: Message, R: tokio::io::AsyncRea
     }
 }
 
+/// Asynchronously read a raw MAVLink message of the specified version, including messages whose ID is unknown to `M`.
+#[cfg(feature = "tokio")]
+pub async fn read_versioned_raw_message_async_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    r: &mut AsyncPeekReader<R>,
+    version: ReadVersion,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    match version {
+        ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
+            read_v2_raw_message_async_inner::<M, _>(r, None, true).await?,
+        )),
+        ReadVersion::Single(MavlinkVersion::V1) => Ok(MAVLinkMessageRaw::V1(
+            read_v1_raw_message_async_inner::<M, _>(r, true).await?,
+        )),
+        ReadVersion::Any => read_any_raw_message_async_inner::<M, _>(r, None, true).await,
+    }
+}
+
 /// Read and parse a MAVLinkMessageRaw of the specified version from a [`PeekReader`] with signing support.
 ///
 /// When using [`ReadVersion::Single`]`(`[`MavlinkVersion::V1`]`)` signing is ignored.
@@ -509,12 +557,30 @@ pub fn read_versioned_raw_message_signed<M: Message, R: Read>(
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
     match version {
         ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
-            read_v2_raw_message_inner::<M, _>(r, signing_data)?,
+            read_v2_raw_message_inner::<M, _>(r, signing_data, false)?,
         )),
         ReadVersion::Single(MavlinkVersion::V1) => {
             Ok(MAVLinkMessageRaw::V1(read_v1_raw_message::<M, _>(r)?))
         }
-        ReadVersion::Any => read_any_raw_message_inner::<M, _>(r, signing_data),
+        ReadVersion::Any => read_any_raw_message_inner::<M, _>(r, signing_data, false),
+    }
+}
+
+/// Read a signed raw MAVLink message of the specified version, including messages whose ID is unknown to `M`.
+#[cfg(feature = "mav2-message-signing")]
+pub fn read_versioned_raw_message_signed_including_unknown<M: Message, R: Read>(
+    r: &mut PeekReader<R>,
+    version: ReadVersion,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    match version {
+        ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
+            read_v2_raw_message_inner::<M, _>(r, signing_data, true)?,
+        )),
+        ReadVersion::Single(MavlinkVersion::V1) => Ok(MAVLinkMessageRaw::V1(
+            read_v1_raw_message_inner::<M, _>(r, true)?,
+        )),
+        ReadVersion::Any => read_any_raw_message_inner::<M, _>(r, signing_data, true),
     }
 }
 
@@ -558,12 +624,33 @@ pub async fn read_versioned_raw_message_async_signed<
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
     match version {
         ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
-            read_v2_raw_message_async_inner::<M, _>(r, signing_data).await?,
+            read_v2_raw_message_async_inner::<M, _>(r, signing_data, false).await?,
         )),
         ReadVersion::Single(MavlinkVersion::V1) => Ok(MAVLinkMessageRaw::V1(
             read_v1_raw_message_async::<M, _>(r).await?,
         )),
-        ReadVersion::Any => read_any_raw_message_async_inner::<M, _>(r, signing_data).await,
+        ReadVersion::Any => read_any_raw_message_async_inner::<M, _>(r, signing_data, false).await,
+    }
+}
+
+/// Asynchronously read a signed raw MAVLink message of the specified version, including messages whose ID is unknown to `M`.
+#[cfg(all(feature = "tokio", feature = "mav2-message-signing"))]
+pub async fn read_versioned_raw_message_async_signed_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    r: &mut AsyncPeekReader<R>,
+    version: ReadVersion,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    match version {
+        ReadVersion::Single(MavlinkVersion::V2) => Ok(MAVLinkMessageRaw::V2(
+            read_v2_raw_message_async_inner::<M, _>(r, signing_data, true).await?,
+        )),
+        ReadVersion::Single(MavlinkVersion::V1) => Ok(MAVLinkMessageRaw::V1(
+            read_v1_raw_message_async_inner::<M, _>(r, true).await?,
+        )),
+        ReadVersion::Any => read_any_raw_message_async_inner::<M, _>(r, signing_data, true).await,
     }
 }
 
@@ -784,6 +871,7 @@ impl MAVLinkV1MessageRaw {
 
 fn try_decode_v1<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
+    allow_unknown: bool,
 ) -> Result<Option<MAVLinkV1MessageRaw>, MessageReadError> {
     let mut message = MAVLinkV1MessageRaw::new();
     let whole_header_size = consts::STX_SIZE + consts::v1::HEADER_SIZE;
@@ -799,7 +887,9 @@ fn try_decode_v1<M: Message, R: Read>(
 
     // retry if CRC failed after previous STX
     // (an STX byte may appear in the middle of a message)
-    if message.has_valid_crc::<M>() {
+    if message.has_valid_crc::<M>()
+        || (allow_unknown && !message_id_is_known::<M>(u32::from(message.message_id())))
+    {
         reader.consume(message.raw_bytes().len());
         Ok(Some(message))
     } else {
@@ -811,6 +901,7 @@ fn try_decode_v1<M: Message, R: Read>(
 // other then the blocking version the STX is read not peeked, this changed some sizes
 async fn try_decode_v1_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
+    allow_unknown: bool,
 ) -> Result<Option<MAVLinkV1MessageRaw>, MessageReadError> {
     let mut message = MAVLinkV1MessageRaw::new();
 
@@ -826,7 +917,9 @@ async fn try_decode_v1_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
 
     // retry if CRC failed after previous STX
     // (an STX byte may appear in the middle of a message)
-    if message.has_valid_crc::<M>() {
+    if message.has_valid_crc::<M>()
+        || (allow_unknown && !message_id_is_known::<M>(u32::from(message.message_id())))
+    {
         reader.consume(message.raw_bytes().len() - consts::STX_SIZE);
         Ok(Some(message))
     } else {
@@ -842,13 +935,30 @@ async fn try_decode_v1_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
 pub fn read_v1_raw_message<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
 ) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_inner::<M, R>(reader, false)
+}
+
+/// Read a raw MAVLink 1 message, including messages whose ID is unknown to `M`.
+///
+/// The CRC of an unknown message cannot be validated because its `CRC_EXTRA`
+/// is not available in `M`.
+pub fn read_v1_raw_message_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_inner::<M, R>(reader, true)
+}
+
+fn read_v1_raw_message_inner<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+    allow_unknown: bool,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of mavlink message
         while reader.peek_exact(consts::STX_SIZE)?[consts::STX_OFFSET] != MAV_STX {
             reader.consume(consts::STX_SIZE);
         }
 
-        if let Some(msg) = try_decode_v1::<M, _>(reader)? {
+        if let Some(msg) = try_decode_v1::<M, _>(reader, allow_unknown)? {
             return Ok(msg);
         }
 
@@ -865,6 +975,25 @@ pub fn read_v1_raw_message<M: Message, R: Read>(
 pub async fn read_v1_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
 ) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_async_inner::<M, R>(reader, false).await
+}
+
+/// Asynchronously read a raw MAVLink 1 message, including messages whose ID is unknown to `M`.
+#[cfg(feature = "tokio")]
+pub async fn read_v1_raw_message_async_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_async_inner::<M, R>(reader, true).await
+}
+
+#[cfg(feature = "tokio")]
+async fn read_v1_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+    allow_unknown: bool,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
     loop {
         loop {
             // search for the magic framing value indicating start of mavlink message
@@ -873,7 +1002,7 @@ pub async fn read_v1_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unp
             }
         }
 
-        if let Some(message) = try_decode_v1_async::<M, _>(reader).await? {
+        if let Some(message) = try_decode_v1_async::<M, _>(reader, allow_unknown).await? {
             return Ok(message);
         }
     }
@@ -888,6 +1017,22 @@ pub async fn read_v1_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unp
 #[cfg(all(feature = "embedded", not(feature = "std")))]
 pub async fn read_v1_raw_message_async<M: Message>(
     reader: &mut impl embedded_io_async::Read,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_embedded_async_inner::<M>(reader, false).await
+}
+
+/// Asynchronously read a raw MAVLink 1 message, including messages whose ID is unknown to `M`.
+#[cfg(all(feature = "embedded", not(feature = "std")))]
+pub async fn read_v1_raw_message_async_including_unknown<M: Message>(
+    reader: &mut impl embedded_io_async::Read,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    read_v1_raw_message_embedded_async_inner::<M>(reader, true).await
+}
+
+#[cfg(all(feature = "embedded", not(feature = "std")))]
+async fn read_v1_raw_message_embedded_async_inner<M: Message>(
+    reader: &mut impl embedded_io_async::Read,
+    allow_unknown: bool,
 ) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of mavlink message
@@ -916,7 +1061,9 @@ pub async fn read_v1_raw_message_async<M: Message>(
 
         // retry if CRC failed after previous STX
         // (an STX byte may appear in the middle of a message)
-        if message.has_valid_crc::<M>() {
+        if message.has_valid_crc::<M>()
+            || (allow_unknown && !message_id_is_known::<M>(u32::from(message.message_id())))
+        {
             return Ok(message);
         }
     }
@@ -930,7 +1077,7 @@ pub async fn read_v1_raw_message_async<M: Message>(
 pub fn read_v1_msg<M: Message, R: Read>(
     r: &mut PeekReader<R>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v1_raw_message::<M, _>(r)?;
+    let message = read_v1_raw_message_inner::<M, _>(r, false)?;
 
     Ok((
         MavHeader {
@@ -955,7 +1102,7 @@ pub fn read_v1_msg<M: Message, R: Read>(
 pub async fn read_v1_msg_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     r: &mut AsyncPeekReader<R>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v1_raw_message_async::<M, _>(r).await?;
+    let message = read_v1_raw_message_async_inner::<M, _>(r, false).await?;
 
     Ok((
         MavHeader {
@@ -979,7 +1126,7 @@ pub async fn read_v1_msg_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
 pub async fn read_v1_msg_async<M: Message>(
     r: &mut impl embedded_io_async::Read,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v1_raw_message_async::<M>(r).await?;
+    let message = read_v1_raw_message_embedded_async_inner::<M>(r, false).await?;
 
     Ok((
         MavHeader {
@@ -1371,6 +1518,7 @@ impl MAVLinkV2MessageRaw {
 fn try_decode_v2<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<Option<MAVLinkV2MessageRaw>, MessageReadError> {
     let mut message = MAVLinkV2MessageRaw::new();
     let whole_header_size = consts::STX_SIZE + consts::v2::HEADER_SIZE;
@@ -1392,7 +1540,9 @@ fn try_decode_v2<M: Message, R: Read>(
         .mut_payload_and_checksum_and_sign()
         .copy_from_slice(payload_and_checksum_and_sign);
 
-    if message.has_valid_crc::<M>() {
+    if message.has_valid_crc::<M>()
+        || (allow_unknown && !message_id_is_known::<M>(message.message_id()))
+    {
         // even if the signature turn out to be invalid the valid crc shows that the received data presents a valid message as opposed to random bytes
         reader.consume(message.raw_bytes().len());
     } else {
@@ -1416,6 +1566,7 @@ fn try_decode_v2<M: Message, R: Read>(
 async fn try_decode_v2_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<Option<MAVLinkV2MessageRaw>, MessageReadError> {
     let mut message = MAVLinkV2MessageRaw::new();
 
@@ -1435,7 +1586,9 @@ async fn try_decode_v2_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
         .mut_payload_and_checksum_and_sign()
         .copy_from_slice(payload_and_checksum_and_sign);
 
-    if message.has_valid_crc::<M>() {
+    if message.has_valid_crc::<M>()
+        || (allow_unknown && !message_id_is_known::<M>(message.message_id()))
+    {
         // even if the signature turn out to be invalid the valid crc shows that the received data presents a valid message as opposed to random bytes
         reader.consume(message.raw_bytes().len() - consts::STX_SIZE);
     } else {
@@ -1461,7 +1614,17 @@ async fn try_decode_v2_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
 pub fn read_v2_raw_message<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
-    read_v2_raw_message_inner::<M, R>(reader, None)
+    read_v2_raw_message_inner::<M, R>(reader, None, false)
+}
+
+/// Read a raw MAVLink 2 message, including messages whose ID is unknown to `M`.
+///
+/// The CRC of an unknown message cannot be validated because its `CRC_EXTRA`
+/// is not available in `M`.
+pub fn read_v2_raw_message_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_inner::<M, R>(reader, None, true)
 }
 
 /// Read a raw MAVLink 2 message with signing support from a [`PeekReader`].
@@ -1475,13 +1638,23 @@ pub fn read_v2_raw_message_signed<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
-    read_v2_raw_message_inner::<M, R>(reader, signing_data)
+    read_v2_raw_message_inner::<M, R>(reader, signing_data, false)
+}
+
+/// Read a signed raw MAVLink 2 message, including messages whose ID is unknown to `M`.
+#[cfg(feature = "mav2-message-signing")]
+pub fn read_v2_raw_message_signed_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_inner::<M, R>(reader, signing_data, true)
 }
 
 #[allow(unused_variables)]
 fn read_v2_raw_message_inner<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of mavlink message
@@ -1489,7 +1662,7 @@ fn read_v2_raw_message_inner<M: Message, R: Read>(
             reader.consume(consts::STX_SIZE);
         }
 
-        if let Some(message) = try_decode_v2::<M, _>(reader, signing_data)? {
+        if let Some(message) = try_decode_v2::<M, _>(reader, signing_data, allow_unknown)? {
             return Ok(message);
         }
     }
@@ -1504,7 +1677,18 @@ fn read_v2_raw_message_inner<M: Message, R: Read>(
 pub async fn read_v2_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
-    read_v2_raw_message_async_inner::<M, R>(reader, None).await
+    read_v2_raw_message_async_inner::<M, R>(reader, None, false).await
+}
+
+/// Asynchronously read a raw MAVLink 2 message, including messages whose ID is unknown to `M`.
+#[cfg(feature = "tokio")]
+pub async fn read_v2_raw_message_async_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_async_inner::<M, R>(reader, None, true).await
 }
 
 #[cfg(feature = "tokio")]
@@ -1512,6 +1696,7 @@ pub async fn read_v2_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unp
 async fn read_v2_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
     loop {
         loop {
@@ -1521,7 +1706,9 @@ async fn read_v2_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + U
             }
         }
 
-        if let Some(message) = try_decode_v2_async::<M, _>(reader, signing_data).await? {
+        if let Some(message) =
+            try_decode_v2_async::<M, _>(reader, signing_data, allow_unknown).await?
+        {
             return Ok(message);
         }
     }
@@ -1537,7 +1724,19 @@ pub async fn read_v2_raw_message_async_signed<M: Message, R: tokio::io::AsyncRea
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
-    read_v2_raw_message_async_inner::<M, R>(reader, signing_data).await
+    read_v2_raw_message_async_inner::<M, R>(reader, signing_data, false).await
+}
+
+/// Asynchronously read a signed raw MAVLink 2 message, including messages whose ID is unknown to `M`.
+#[cfg(all(feature = "tokio", feature = "mav2-message-signing"))]
+pub async fn read_v2_raw_message_async_signed_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    reader: &mut AsyncPeekReader<R>,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_async_inner::<M, R>(reader, signing_data, true).await
 }
 
 /// Asynchronously read a raw MAVLink 2 message with signing support from a [`embedded_io_async::Read`]er.
@@ -1548,6 +1747,22 @@ pub async fn read_v2_raw_message_async_signed<M: Message, R: tokio::io::AsyncRea
 #[cfg(all(feature = "embedded", not(feature = "std")))]
 pub async fn read_v2_raw_message_async<M: Message>(
     reader: &mut impl embedded_io_async::Read,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_embedded_async_inner::<M>(reader, false).await
+}
+
+/// Asynchronously read a raw MAVLink 2 message, including messages whose ID is unknown to `M`.
+#[cfg(all(feature = "embedded", not(feature = "std")))]
+pub async fn read_v2_raw_message_async_including_unknown<M: Message>(
+    reader: &mut impl embedded_io_async::Read,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    read_v2_raw_message_embedded_async_inner::<M>(reader, true).await
+}
+
+#[cfg(all(feature = "embedded", not(feature = "std")))]
+async fn read_v2_raw_message_embedded_async_inner<M: Message>(
+    reader: &mut impl embedded_io_async::Read,
+    allow_unknown: bool,
 ) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of mavlink message
@@ -1582,7 +1797,9 @@ pub async fn read_v2_raw_message_async<M: Message>(
 
         // retry if CRC failed after previous STX
         // (an STX byte may appear in the middle of a message)
-        if message.has_valid_crc::<M>() {
+        if message.has_valid_crc::<M>()
+            || (allow_unknown && !message_id_is_known::<M>(message.message_id()))
+        {
             return Ok(message);
         }
     }
@@ -1618,7 +1835,7 @@ fn read_v2_msg_inner<M: Message, R: Read>(
     read: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v2_raw_message_inner::<M, _>(read, signing_data)?;
+    let message = read_v2_raw_message_inner::<M, _>(read, signing_data, false)?;
 
     Ok((
         MavHeader {
@@ -1660,7 +1877,7 @@ async fn read_v2_msg_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
     read: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v2_raw_message_async_inner::<M, _>(read, signing_data).await?;
+    let message = read_v2_raw_message_async_inner::<M, _>(read, signing_data, false).await?;
 
     Ok((
         MavHeader {
@@ -1680,7 +1897,7 @@ async fn read_v2_msg_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
 pub async fn read_v2_msg_async<M: Message, R: embedded_io_async::Read>(
     r: &mut R,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_v2_raw_message_async::<M>(r).await?;
+    let message = read_v2_raw_message_embedded_async_inner::<M>(r, false).await?;
 
     Ok((
         MavHeader {
@@ -1750,7 +1967,14 @@ impl MAVLinkMessageRaw {
 pub fn read_any_raw_message<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
-    read_any_raw_message_inner::<M, R>(reader, None)
+    read_any_raw_message_inner::<M, R>(reader, None, false)
+}
+
+/// Read a raw MAVLink 1 or 2 message, including messages whose ID is unknown to `M`.
+pub fn read_any_raw_message_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    read_any_raw_message_inner::<M, R>(reader, None, true)
 }
 
 /// Read a raw MAVLink 1 or 2 message from a [`PeekReader`] with signing support.
@@ -1764,13 +1988,23 @@ pub fn read_any_raw_message_signed<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
-    read_any_raw_message_inner::<M, R>(reader, signing_data)
+    read_any_raw_message_inner::<M, R>(reader, signing_data, false)
+}
+
+/// Read a signed raw MAVLink 1 or 2 message, including messages whose ID is unknown to `M`.
+#[cfg(feature = "mav2-message-signing")]
+pub fn read_any_raw_message_signed_including_unknown<M: Message, R: Read>(
+    reader: &mut PeekReader<R>,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    read_any_raw_message_inner::<M, R>(reader, signing_data, true)
 }
 
 #[allow(unused_variables)]
 fn read_any_raw_message_inner<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of MAVLink message
@@ -1786,7 +2020,7 @@ fn read_any_raw_message_inner<M: Message, R: Read>(
         };
         match version {
             MavlinkVersion::V1 => {
-                if let Some(message) = try_decode_v1::<M, _>(reader)? {
+                if let Some(message) = try_decode_v1::<M, _>(reader, allow_unknown)? {
                     // With signing enabled and unsigned messages not allowed do not further process V1
                     #[cfg(feature = "mav2-message-signing")]
                     if let Some(signing) = signing_data {
@@ -1803,7 +2037,7 @@ fn read_any_raw_message_inner<M: Message, R: Read>(
                 reader.consume(consts::STX_SIZE);
             }
             MavlinkVersion::V2 => {
-                if let Some(message) = try_decode_v2::<M, _>(reader, signing_data)? {
+                if let Some(message) = try_decode_v2::<M, _>(reader, signing_data, allow_unknown)? {
                     return Ok(MAVLinkMessageRaw::V2(message));
                 }
             }
@@ -1820,7 +2054,18 @@ fn read_any_raw_message_inner<M: Message, R: Read>(
 pub async fn read_any_raw_message_async<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
-    read_any_raw_message_async_inner::<M, R>(reader, None).await
+    read_any_raw_message_async_inner::<M, R>(reader, None, false).await
+}
+
+/// Asynchronously read a raw MAVLink 1 or 2 message, including messages whose ID is unknown to `M`.
+#[cfg(feature = "tokio")]
+pub async fn read_any_raw_message_async_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    read_any_raw_message_async_inner::<M, R>(reader, None, true).await
 }
 
 /// Asynchronously read a raw MAVLink 1 or 2 message from a [`AsyncPeekReader`] with signing support.
@@ -1835,7 +2080,19 @@ pub async fn read_any_raw_message_async_signed<M: Message, R: tokio::io::AsyncRe
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
-    read_any_raw_message_async_inner::<M, R>(reader, signing_data).await
+    read_any_raw_message_async_inner::<M, R>(reader, signing_data, false).await
+}
+
+/// Asynchronously read a signed raw MAVLink 1 or 2 message, including messages whose ID is unknown to `M`.
+#[cfg(all(feature = "tokio", feature = "mav2-message-signing"))]
+pub async fn read_any_raw_message_async_signed_including_unknown<
+    M: Message,
+    R: tokio::io::AsyncRead + Unpin,
+>(
+    reader: &mut AsyncPeekReader<R>,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkMessageRaw, MessageReadError> {
+    read_any_raw_message_async_inner::<M, R>(reader, signing_data, true).await
 }
 
 #[cfg(feature = "tokio")]
@@ -1843,6 +2100,7 @@ pub async fn read_any_raw_message_async_signed<M: Message, R: tokio::io::AsyncRe
 async fn read_any_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
     reader: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
+    allow_unknown: bool,
 ) -> Result<MAVLinkMessageRaw, MessageReadError> {
     loop {
         // search for the magic framing value indicating start of MAVLink 1 or 2 message
@@ -1858,7 +2116,7 @@ async fn read_any_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + 
 
         match version {
             MavlinkVersion::V1 => {
-                if let Some(message) = try_decode_v1_async::<M, _>(reader).await? {
+                if let Some(message) = try_decode_v1_async::<M, _>(reader, allow_unknown).await? {
                     // With signing enabled and unsigned messages not allowed do not further process them
                     #[cfg(feature = "mav2-message-signing")]
                     if let Some(signing) = signing_data {
@@ -1873,7 +2131,9 @@ async fn read_any_raw_message_async_inner<M: Message, R: tokio::io::AsyncRead + 
                 }
             }
             MavlinkVersion::V2 => {
-                if let Some(message) = try_decode_v2_async::<M, _>(reader, signing_data).await? {
+                if let Some(message) =
+                    try_decode_v2_async::<M, _>(reader, signing_data, allow_unknown).await?
+                {
                     return Ok(MAVLinkMessageRaw::V2(message));
                 }
             }
@@ -1913,7 +2173,7 @@ fn read_any_msg_inner<M: Message, R: Read>(
     read: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_any_raw_message_inner::<M, _>(read, signing_data)?;
+    let message = read_any_raw_message_inner::<M, _>(read, signing_data, false)?;
     Ok((
         MavHeader {
             sequence: message.sequence(),
@@ -1957,7 +2217,7 @@ async fn read_any_msg_async_inner<M: Message, R: tokio::io::AsyncRead + Unpin>(
     read: &mut AsyncPeekReader<R>,
     signing_data: Option<&SigningData>,
 ) -> Result<(MavHeader, M), MessageReadError> {
-    let message = read_any_raw_message_async_inner::<M, _>(read, signing_data).await?;
+    let message = read_any_raw_message_async_inner::<M, _>(read, signing_data, false).await?;
 
     Ok((
         MavHeader {

--- a/mavlink/tests/unknown_raw_message_tests.rs
+++ b/mavlink/tests/unknown_raw_message_tests.rs
@@ -1,0 +1,175 @@
+#![cfg(feature = "dialect-common")]
+
+use mavlink::{
+    MAV_STX, MAV_STX_V2, MAVLinkMessageRaw, MAVLinkV2MessageRaw, MavConnection, MavHeader, Message,
+    calculate_crc, dialects::common::MavMessage, error::ParserError, peek_reader::PeekReader,
+};
+
+const UNKNOWN_V1_ID: u8 = 255;
+const UNKNOWN_V2_ID: u32 = 0x00_ff_fe;
+const UNKNOWN_CRC_EXTRA: u8 = 123;
+const PAYLOAD: &[u8] = &[0x12, 0xfe, 0xfd, 0x34];
+
+fn unknown_v1_frame() -> Vec<u8> {
+    assert!(MavMessage::default_message_from_id(UNKNOWN_V1_ID.into()).is_none());
+
+    let mut frame = vec![MAV_STX, PAYLOAD.len() as u8, 42, 7, 8, UNKNOWN_V1_ID];
+    frame.extend_from_slice(PAYLOAD);
+    let checksum = calculate_crc(&frame[1..], UNKNOWN_CRC_EXTRA);
+    frame.extend_from_slice(&checksum.to_le_bytes());
+    frame
+}
+
+fn unknown_v2_frame() -> Vec<u8> {
+    assert!(MavMessage::default_message_from_id(UNKNOWN_V2_ID).is_none());
+
+    let id = UNKNOWN_V2_ID.to_le_bytes();
+    let mut frame = vec![
+        MAV_STX_V2,
+        PAYLOAD.len() as u8,
+        0,
+        0,
+        43,
+        9,
+        10,
+        id[0],
+        id[1],
+        id[2],
+    ];
+    frame.extend_from_slice(PAYLOAD);
+    let checksum = calculate_crc(&frame[1..], UNKNOWN_CRC_EXTRA);
+    frame.extend_from_slice(&checksum.to_le_bytes());
+    frame
+}
+
+fn known_v2_frame() -> Vec<u8> {
+    let known = MavMessage::default_message_from_id(0).unwrap();
+    let mut raw = MAVLinkV2MessageRaw::new();
+    raw.serialize_message(MavHeader::default(), &known);
+    raw.raw_bytes().to_vec()
+}
+
+#[test]
+fn raw_reader_preserves_unknown_v1_frame() {
+    let bytes = unknown_v1_frame();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let raw = mavlink::read_v1_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+
+    assert_eq!(raw.message_id(), UNKNOWN_V1_ID);
+    assert_eq!(raw.payload(), PAYLOAD);
+    assert_eq!(raw.raw_bytes(), bytes);
+    assert!(!raw.has_valid_crc::<MavMessage>());
+}
+
+#[test]
+fn raw_reader_preserves_unknown_v2_frame() {
+    let bytes = unknown_v2_frame();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let raw = mavlink::read_v2_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+
+    assert_eq!(raw.message_id(), UNKNOWN_V2_ID);
+    assert_eq!(raw.payload(), PAYLOAD);
+    assert_eq!(raw.raw_bytes(), bytes);
+    assert!(!raw.has_valid_crc::<MavMessage>());
+}
+
+#[test]
+fn existing_raw_reader_does_not_return_unknown_messages() {
+    let unknown = unknown_v2_frame();
+    let known = known_v2_frame();
+    let bytes = [unknown.as_slice(), known.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let received = mavlink::read_v2_raw_message::<MavMessage, _>(&mut reader).unwrap();
+
+    assert_eq!(received.raw_bytes(), known);
+}
+
+#[test]
+fn version_agnostic_raw_reader_preserves_unknown_frames() {
+    let v1 = unknown_v1_frame();
+    let v2 = unknown_v2_frame();
+    let bytes = [v1.as_slice(), v2.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let first =
+        mavlink::read_any_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+    let second =
+        mavlink::read_any_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+
+    assert!(matches!(first, MAVLinkMessageRaw::V1(ref raw) if raw.raw_bytes() == v1));
+    assert!(matches!(second, MAVLinkMessageRaw::V2(ref raw) if raw.raw_bytes() == v2));
+}
+
+#[test]
+fn preserved_unknown_frame_cannot_be_parsed_by_the_dialect() {
+    let bytes = unknown_v2_frame();
+    let mut reader = PeekReader::new(bytes.as_slice());
+    let raw = mavlink::read_v2_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+
+    let error = MavMessage::parse(mavlink::MavlinkVersion::V2, raw.message_id(), raw.payload())
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        ParserError::UnknownMessage { id: UNKNOWN_V2_ID }
+    ));
+}
+
+#[test]
+fn raw_reader_still_rejects_bad_crc_for_known_messages() {
+    let known = MavMessage::default_message_from_id(0).unwrap();
+    let mut raw = MAVLinkV2MessageRaw::new();
+    raw.serialize_message(MavHeader::default(), &known);
+    let mut corrupt_known = raw.raw_bytes().to_vec();
+    *corrupt_known.last_mut().unwrap() ^= 0xff;
+
+    let unknown = unknown_v2_frame();
+    let bytes = [corrupt_known.as_slice(), unknown.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let received =
+        mavlink::read_v2_raw_message_including_unknown::<MavMessage, _>(&mut reader).unwrap();
+
+    assert_eq!(received.raw_bytes(), unknown);
+}
+
+#[test]
+fn connection_requires_explicit_opt_in_for_unknown_messages() {
+    let path = std::env::temp_dir().join(format!(
+        "rust-mavlink-unknown-message-{}.tlog",
+        std::process::id()
+    ));
+    let unknown = unknown_v2_frame();
+    std::fs::write(&path, &unknown).unwrap();
+
+    let connection = mavlink::connect::<MavMessage>(&format!("file:{}", path.display())).unwrap();
+    let received = connection.recv_raw_including_unknown().unwrap();
+
+    assert!(matches!(received, MAVLinkMessageRaw::V2(ref raw) if raw.raw_bytes() == unknown));
+    std::fs::remove_file(path).unwrap();
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_raw_reader_preserves_unknown_frames() {
+    use mavlink::async_peek_reader::AsyncPeekReader;
+
+    let v1 = unknown_v1_frame();
+    let v2 = unknown_v2_frame();
+    let bytes = [v1.as_slice(), v2.as_slice()].concat();
+    let mut reader = AsyncPeekReader::new(bytes.as_slice());
+
+    let first = mavlink::read_any_raw_message_async_including_unknown::<MavMessage, _>(&mut reader)
+        .await
+        .unwrap();
+    let second =
+        mavlink::read_any_raw_message_async_including_unknown::<MavMessage, _>(&mut reader)
+            .await
+            .unwrap();
+
+    assert!(matches!(first, MAVLinkMessageRaw::V1(ref raw) if raw.raw_bytes() == v1));
+    assert!(matches!(second, MAVLinkMessageRaw::V2(ref raw) if raw.raw_bytes() == v2));
+}


### PR DESCRIPTION
New method that allows receiving unknown mavlink messages unknown to our mavlink definition source.

This is something I've had for a while and decided to PR since this is very useful in cases where we're dealing with custom mavlink definitions and one of the softwares is still missing the messages because it wasn't updated on time