### PR TITLE
Implemented method to retrieve mavlink sha

### DIFF
--- a/mavlink/build/main.rs
+++ b/mavlink/build/main.rs
@@ -29,20 +29,18 @@ fn main() -> ExitCode {
             eprintln!("Failed to update MAVLink definitions submodule: {error}");
             return ExitCode::FAILURE;
         }
-    }
 
-    // Get the MAVLink submodule SHA
-    let mavlink_dir = src_dir.join("mavlink");
-    let sha_output = Command::new("git")
-        .arg("rev-parse")
-        .arg("HEAD")
-        .current_dir(&mavlink_dir)
-        .output();
+        let sha_output = Command::new("git")
+            .arg("rev-parse")
+            .arg("HEAD")
+            .current_dir(&mavlink_dir)
+            .output();
 
-    if let Ok(output) = sha_output {
-        if output.status.success() {
-            let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            println!("cargo:rustc-env=MAVLINK_SHA={sha}");
+        if let Ok(output) = sha_output {
+            if output.status.success() {
+                let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                println!("cargo:rustc-env=MAVLINK_SHA={sha}");
+            }
         }
     }
 

--- a/mavlink/build/main.rs
+++ b/mavlink/build/main.rs
@@ -31,6 +31,21 @@ fn main() -> ExitCode {
         }
     }
 
+    // Get the MAVLink submodule SHA
+    let mavlink_dir = src_dir.join("mavlink");
+    let sha_output = Command::new("git")
+        .arg("rev-parse")
+        .arg("HEAD")
+        .current_dir(&mavlink_dir)
+        .output();
+
+    if let Ok(output) = sha_output {
+        if output.status.success() {
+            let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            println!("cargo:rustc-env=MAVLINK_SHA={sha}");
+        }
+    }
+
     // find & apply patches to XML definitions to avoid crashes
     let patch_dir = src_dir.join("build/patches");
     if let Ok(dir) = read_dir(patch_dir) {

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -84,16 +84,17 @@ pub mod dialects {
     //! - dialect-ualberta
     //! - dialect-uavionix
 
-    /// Git SHA of the MAVLink definitions used to generate the bindings.
+    /// Git SHA of the MAVLink definitions used to generate the bindings, when available.
     ///
-    /// This corresponds to the commit hash in the `mavlink` submodule at build time.
+    /// This is [`None`] for vendored builds and builds performed without Git metadata.
     ///
     /// # Example
     /// ```
-    /// let sha = mavlink::dialects::MAVLINK_DEFINITIONS_SHA;
-    /// println!("Using MAVLink definitions from commit: {sha}");
+    /// if let Some(sha) = mavlink::dialects::MAVLINK_DEFINITIONS_SHA {
+    ///     println!("Using MAVLink definitions from commit: {sha}");
+    /// }
     /// ```
-    pub const MAVLINK_DEFINITIONS_SHA: &str = env!("MAVLINK_SHA");
+    pub const MAVLINK_DEFINITIONS_SHA: Option<&str> = option_env!("MAVLINK_SHA");
 
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -83,20 +83,19 @@ pub mod dialects {
     //! - dialect-test
     //! - dialect-ualberta
     //! - dialect-uavionix
+
+    /// Git SHA of the MAVLink definitions used to generate the bindings.
+    ///
+    /// This corresponds to the commit hash in the `mavlink` submodule at build time.
+    ///
+    /// # Example
+    /// ```
+    /// let sha = mavlink::dialects::MAVLINK_DEFINITIONS_SHA;
+    /// println!("Using MAVLink definitions from commit: {sha}");
+    /// ```
+    pub const MAVLINK_DEFINITIONS_SHA: &str = env!("MAVLINK_SHA");
+
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
 }
 
 pub use mavlink_core::*;
-
-/// Returns the git SHA of the MAVLink definitions used to generate the bindings.
-///
-/// This corresponds to the commit hash in the `mavlink` submodule at build time.
-///
-/// # Example
-/// ```
-/// let sha = mavlink::mavlink_definitions_sha();
-/// println!("Using MAVLink definitions from commit: {sha}");
-/// ```
-pub const fn mavlink_definitions_sha() -> &'static str {
-    env!("MAVLINK_SHA")
-}

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -87,3 +87,16 @@ pub mod dialects {
 }
 
 pub use mavlink_core::*;
+
+/// Returns the git SHA of the MAVLink definitions used to generate the bindings.
+///
+/// This corresponds to the commit hash in the `mavlink` submodule at build time.
+///
+/// # Example
+/// ```
+/// let sha = mavlink::mavlink_definitions_sha();
+/// println!("Using MAVLink definitions from commit: {sha}");
+/// ```
+pub const fn mavlink_definitions_sha() -> &'static str {
+    env!("MAVLINK_SHA")
+}

--- a/mavlink/src/lib.rs
+++ b/mavlink/src/lib.rs
@@ -86,14 +86,7 @@ pub mod dialects {
 
     /// Git SHA of the MAVLink definitions used to generate the bindings, when available.
     ///
-    /// This is [`None`] for vendored builds and builds performed without Git metadata.
-    ///
-    /// # Example
-    /// ```
-    /// if let Some(sha) = mavlink::dialects::MAVLINK_DEFINITIONS_SHA {
-    ///     println!("Using MAVLink definitions from commit: {sha}");
-    /// }
-    /// ```
+    /// This is [`None`] when `git` fails to resolve the commit SHA.
     pub const MAVLINK_DEFINITIONS_SHA: Option<&str> = option_env!("MAVLINK_SHA");
 
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));


### PR DESCRIPTION
New method that allows whoever uses this crate to print out the mavlink commit sha being used

Similar to https://github.com/mavlink/rust-mavlink/pull/530

Something I've had for a while that I believe to be very useful on scenarios where multiple softwares speak mavlink and need to be aligned

