### PR TITLE
Added support for reading unverified frames from unknown mavlink definitions

### DIFF
--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -1,4 +1,4 @@
-use crate::bytes;
+use crate::{MAVLinkUnverifiedFrame, bytes};
 use core::fmt::{Display, Formatter};
 #[cfg(feature = "std")]
 use std::error::Error;
@@ -49,6 +49,30 @@ pub enum MessageReadError {
     Parse(ParserError),
 }
 
+/// Error returned when an unverified frame fails validation.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct FrameValidationError {
+    /// The complete unverified frame.
+    pub frame: MAVLinkUnverifiedFrame,
+    /// The verification step that failed.
+    pub reason: FrameValidationErrorKind,
+}
+
+/// Reason why a structurally complete MAVLink frame could not be verified.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum FrameValidationErrorKind {
+    /// The frame checksum does not match the selected dialect.
+    InvalidChecksum,
+    /// MAVLink 2 incompatibility flags contain unsupported bits.
+    UnsupportedIncompatibilityFlags { flags: u8 },
+    /// MAVLink 2 signature verification failed.
+    #[cfg(feature = "mav2-message-signing")]
+    InvalidSignature,
+    /// Signing is required, but the frame is unsigned or MAVLink 1.
+    #[cfg(feature = "mav2-message-signing")]
+    UnsignedNotAllowed,
+}
+
 impl MessageReadError {
     pub fn eof() -> Self {
         #[cfg(feature = "std")]
@@ -69,6 +93,15 @@ impl Display for MessageReadError {
         }
     }
 }
+
+impl Display for FrameValidationError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "Failed to verify MAVLink frame: {:?}", self.reason)
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for FrameValidationError {}
 
 #[cfg(feature = "std")]
 impl Error for MessageReadError {}

--- a/mavlink-core/src/error.rs
+++ b/mavlink-core/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{MAVLinkUnverifiedFrame, bytes};
+use crate::bytes;
 use core::fmt::{Display, Formatter};
 #[cfg(feature = "std")]
 use std::error::Error;
@@ -52,8 +52,6 @@ pub enum MessageReadError {
 /// Error returned when an unverified frame fails validation.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FrameValidationError {
-    /// The complete unverified frame.
-    pub frame: MAVLinkUnverifiedFrame,
     /// The verification step that failed.
     pub reason: FrameValidationErrorKind,
 }

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -84,9 +84,6 @@
 #![deny(clippy::all)]
 #![warn(clippy::use_self)]
 
-extern crate alloc;
-
-use alloc::boxed::Box;
 use core::result::Result;
 
 #[cfg(feature = "std")]
@@ -1878,20 +1875,20 @@ impl MAVLinkUnverifiedFrame {
 
     /// Validate this frame against message dialect `M`.
     ///
-    /// On failure the returned error retains this complete unverified frame.
-    pub fn validate<M: Message>(self) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
-        validate_unverified_frame::<M>(self, None)
+    /// On failure the caller retains this complete unverified frame.
+    pub fn validate<M: Message>(&self) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+        validate_unverified_frame::<M>(*self, None)
     }
 
     /// Validate this frame against message dialect `M` and optional signing configuration.
     ///
-    /// On failure the returned error retains this complete unverified frame.
+    /// On failure the caller retains this complete unverified frame.
     #[cfg(feature = "mav2-message-signing")]
     pub fn validate_signed<M: Message>(
-        self,
+        &self,
         signing_data: Option<&SigningData>,
-    ) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
-        validate_unverified_frame::<M>(self, signing_data)
+    ) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+        validate_unverified_frame::<M>(*self, signing_data)
     }
 }
 
@@ -1899,47 +1896,42 @@ impl MAVLinkUnverifiedFrame {
 fn validate_unverified_frame<M: Message>(
     unverified: MAVLinkUnverifiedFrame,
     signing_data: Option<&SigningData>,
-) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
+) -> Result<MAVLinkMessageRaw, FrameValidationError> {
     match unverified {
         MAVLinkUnverifiedFrame::V1(frame) => {
             if !frame.has_valid_crc::<M>() {
-                return Err(Box::new(FrameValidationError {
-                    frame: unverified,
+                return Err(FrameValidationError {
                     reason: FrameValidationErrorKind::InvalidChecksum,
-                }));
+                });
             }
             #[cfg(feature = "mav2-message-signing")]
             if signing_data.is_some_and(|signing| !signing.config.allow_unsigned) {
-                return Err(Box::new(FrameValidationError {
-                    frame: unverified,
+                return Err(FrameValidationError {
                     reason: FrameValidationErrorKind::UnsignedNotAllowed,
-                }));
+                });
             }
             Ok(MAVLinkMessageRaw::V1(frame))
         }
         MAVLinkUnverifiedFrame::V2(frame) => {
             let unsupported_flags = frame.incompatibility_flags() & !consts::v2::SUPPORTED_IFLAGS;
             if unsupported_flags != 0 {
-                return Err(Box::new(FrameValidationError {
-                    frame: unverified,
+                return Err(FrameValidationError {
                     reason: FrameValidationErrorKind::UnsupportedIncompatibilityFlags {
                         flags: unsupported_flags,
                     },
-                }));
+                });
             }
             if !frame.has_valid_crc::<M>() {
-                return Err(Box::new(FrameValidationError {
-                    frame: unverified,
+                return Err(FrameValidationError {
                     reason: FrameValidationErrorKind::InvalidChecksum,
-                }));
+                });
             }
             #[cfg(feature = "mav2-message-signing")]
             if let Some(signing) = signing_data {
                 if !signing.verify_signature(&frame) {
-                    return Err(Box::new(FrameValidationError {
-                        frame: unverified,
+                    return Err(FrameValidationError {
                         reason: FrameValidationErrorKind::InvalidSignature,
-                    }));
+                    });
                 }
             }
             Ok(MAVLinkMessageRaw::V2(frame))

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -101,7 +101,10 @@ use peek_reader::PeekReader;
 
 use crate::{
     bytes::Bytes,
-    error::{MessageReadError, MessageWriteError, ParserError},
+    error::{
+        FrameValidationError, FrameValidationErrorKind, MessageReadError, MessageWriteError,
+        ParserError,
+    },
 };
 
 use crc_any::CRCu16;
@@ -782,6 +785,36 @@ impl MAVLinkV1MessageRaw {
     }
 }
 
+fn read_v1_unverified_at_stx<R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    let mut frame = MAVLinkV1MessageRaw::new();
+    let header_end = consts::STX_SIZE + consts::v1::HEADER_SIZE;
+
+    frame.0[consts::STX_OFFSET] = MAV_STX;
+    frame
+        .mut_header()
+        .copy_from_slice(&reader.peek_exact(header_end)?[consts::STX_SIZE..header_end]);
+    let frame_len = frame.raw_bytes().len();
+    frame
+        .mut_payload_and_checksum()
+        .copy_from_slice(&reader.peek_exact(frame_len)?[header_end..frame_len]);
+    reader.consume(frame_len);
+    Ok(frame)
+}
+
+/// Reads the next MAVLink 1 frame without validating it.
+///
+/// No checksum verification is performed
+pub fn read_v1_unverified<R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    while reader.peek_exact(consts::STX_SIZE)?[consts::STX_OFFSET] != MAV_STX {
+        reader.consume(consts::STX_SIZE);
+    }
+    read_v1_unverified_at_stx(reader).map(MAVLinkUnverifiedFrame::V1)
+}
+
 fn try_decode_v1<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
 ) -> Result<Option<MAVLinkV1MessageRaw>, MessageReadError> {
@@ -805,6 +838,35 @@ fn try_decode_v1<M: Message, R: Read>(
     } else {
         Ok(None)
     }
+}
+
+#[cfg(feature = "tokio")]
+async fn read_v1_unverified_after_stx_async<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkV1MessageRaw, MessageReadError> {
+    let mut frame = MAVLinkV1MessageRaw::new();
+    frame.0[consts::STX_OFFSET] = MAV_STX;
+    frame.mut_header().copy_from_slice(
+        &reader.peek_exact(consts::v1::HEADER_SIZE).await?[..consts::v1::HEADER_SIZE],
+    );
+    let frame_len_without_stx = frame.raw_bytes().len() - consts::STX_SIZE;
+    frame.mut_payload_and_checksum().copy_from_slice(
+        &reader.peek_exact(frame_len_without_stx).await?
+            [consts::v1::HEADER_SIZE..frame_len_without_stx],
+    );
+    reader.consume(frame_len_without_stx);
+    Ok(frame)
+}
+
+/// Asynchronously reads the next MAVLink 1 frame without validating it.
+#[cfg(feature = "tokio")]
+pub async fn read_v1_unverified_async<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    while reader.read_u8().await? != MAV_STX {}
+    read_v1_unverified_after_stx_async(reader)
+        .await
+        .map(MAVLinkUnverifiedFrame::V1)
 }
 
 #[cfg(feature = "tokio")]
@@ -1368,6 +1430,38 @@ impl MAVLinkV2MessageRaw {
 }
 
 #[allow(unused_variables)]
+fn read_v2_unverified_at_stx<R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    let mut frame = MAVLinkV2MessageRaw::new();
+    let header_end = consts::STX_SIZE + consts::v2::HEADER_SIZE;
+
+    frame.0[consts::STX_OFFSET] = MAV_STX_V2;
+    frame
+        .mut_header()
+        .copy_from_slice(&reader.peek_exact(header_end)?[consts::STX_SIZE..header_end]);
+    let frame_len = frame.raw_bytes().len();
+    frame
+        .mut_payload_and_checksum_and_sign()
+        .copy_from_slice(&reader.peek_exact(frame_len)?[header_end..frame_len]);
+    reader.consume(frame_len);
+    Ok(frame)
+}
+
+/// Read the next structurally complete MAVLink 2 frame without validating it.
+///
+/// No compatibility-flag, checksum, or signature verification is performed.
+/// Callers must treat the returned bytes as untrusted.
+pub fn read_v2_unverified<R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    while reader.peek_exact(consts::STX_SIZE)?[consts::STX_OFFSET] != MAV_STX_V2 {
+        reader.consume(consts::STX_SIZE);
+    }
+    read_v2_unverified_at_stx(reader).map(MAVLinkUnverifiedFrame::V2)
+}
+
+#[allow(unused_variables)]
 fn try_decode_v2<M: Message, R: Read>(
     reader: &mut PeekReader<R>,
     signing_data: Option<&SigningData>,
@@ -1408,6 +1502,36 @@ fn try_decode_v2<M: Message, R: Read>(
     }
 
     Ok(Some(message))
+}
+
+#[cfg(feature = "tokio")]
+#[allow(unused_variables)]
+async fn read_v2_unverified_after_stx_async<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkV2MessageRaw, MessageReadError> {
+    let mut frame = MAVLinkV2MessageRaw::new();
+    frame.0[consts::STX_OFFSET] = MAV_STX_V2;
+    frame.mut_header().copy_from_slice(
+        &reader.peek_exact(consts::v2::HEADER_SIZE).await?[..consts::v2::HEADER_SIZE],
+    );
+    let frame_len_without_stx = frame.raw_bytes().len() - consts::STX_SIZE;
+    frame.mut_payload_and_checksum_and_sign().copy_from_slice(
+        &reader.peek_exact(frame_len_without_stx).await?
+            [consts::v2::HEADER_SIZE..frame_len_without_stx],
+    );
+    reader.consume(frame_len_without_stx);
+    Ok(frame)
+}
+
+/// Asynchronously read the next structurally complete MAVLink 2 frame without validating it.
+#[cfg(feature = "tokio")]
+pub async fn read_v2_unverified_async<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    while reader.read_u8().await? != MAV_STX_V2 {}
+    read_v2_unverified_after_stx_async(reader)
+        .await
+        .map(MAVLinkUnverifiedFrame::V2)
 }
 
 #[cfg(feature = "tokio")]
@@ -1700,6 +1824,168 @@ pub async fn read_v2_msg_async<M: Message, R: embedded_io_async::Read>(
 pub enum MAVLinkMessageRaw {
     V1(MAVLinkV1MessageRaw),
     V2(MAVLinkV2MessageRaw),
+}
+
+/// A structurally complete MAVLink frame that has not been verified.
+///
+/// This type makes no claim that the checksum, incompatibility flags, or
+/// signature are valid. It is intended for low-level inspection and transparent
+/// forwarding when the message definition (and therefore `CRC_EXTRA`) is not
+/// available locally.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum MAVLinkUnverifiedFrame {
+    /// An unverified MAVLink 1 frame.
+    V1(MAVLinkV1MessageRaw),
+    /// An unverified MAVLink 2 frame.
+    V2(MAVLinkV2MessageRaw),
+}
+
+impl MAVLinkUnverifiedFrame {
+    /// Return the complete frame bytes, including STX and checksum.
+    pub fn raw_bytes(&self) -> &[u8] {
+        match self {
+            Self::V1(frame) => frame.raw_bytes(),
+            Self::V2(frame) => frame.raw_bytes(),
+        }
+    }
+
+    /// Return the protocol version indicated by the frame marker.
+    pub const fn version(&self) -> MavlinkVersion {
+        match self {
+            Self::V1(_) => MavlinkVersion::V1,
+            Self::V2(_) => MavlinkVersion::V2,
+        }
+    }
+
+    /// Return the message ID encoded in the frame header.
+    pub fn message_id(&self) -> u32 {
+        match self {
+            Self::V1(frame) => frame.message_id().into(),
+            Self::V2(frame) => frame.message_id(),
+        }
+    }
+
+    /// Convert into the existing raw-message representation.
+    pub const fn into_raw_message(self) -> MAVLinkMessageRaw {
+        match self {
+            Self::V1(frame) => MAVLinkMessageRaw::V1(frame),
+            Self::V2(frame) => MAVLinkMessageRaw::V2(frame),
+        }
+    }
+
+    /// Validate this frame against message dialect `M`.
+    ///
+    /// On failure the returned error retains this complete unverified frame.
+    pub fn validate<M: Message>(self) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+        validate_unverified_frame::<M>(self, None)
+    }
+
+    /// Validate this frame against message dialect `M` and optional signing configuration.
+    ///
+    /// On failure the returned error retains this complete unverified frame.
+    #[cfg(feature = "mav2-message-signing")]
+    pub fn validate_signed<M: Message>(
+        self,
+        signing_data: Option<&SigningData>,
+    ) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+        validate_unverified_frame::<M>(self, signing_data)
+    }
+}
+
+#[allow(unused_variables)]
+fn validate_unverified_frame<M: Message>(
+    unverified: MAVLinkUnverifiedFrame,
+    signing_data: Option<&SigningData>,
+) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+    match unverified {
+        MAVLinkUnverifiedFrame::V1(frame) => {
+            if !frame.has_valid_crc::<M>() {
+                return Err(FrameValidationError {
+                    frame: unverified,
+                    reason: FrameValidationErrorKind::InvalidChecksum,
+                });
+            }
+            #[cfg(feature = "mav2-message-signing")]
+            if signing_data.is_some_and(|signing| !signing.config.allow_unsigned) {
+                return Err(FrameValidationError {
+                    frame: unverified,
+                    reason: FrameValidationErrorKind::UnsignedNotAllowed,
+                });
+            }
+            Ok(MAVLinkMessageRaw::V1(frame))
+        }
+        MAVLinkUnverifiedFrame::V2(frame) => {
+            let unsupported_flags = frame.incompatibility_flags() & !consts::v2::SUPPORTED_IFLAGS;
+            if unsupported_flags != 0 {
+                return Err(FrameValidationError {
+                    frame: unverified,
+                    reason: FrameValidationErrorKind::UnsupportedIncompatibilityFlags {
+                        flags: unsupported_flags,
+                    },
+                });
+            }
+            if !frame.has_valid_crc::<M>() {
+                return Err(FrameValidationError {
+                    frame: unverified,
+                    reason: FrameValidationErrorKind::InvalidChecksum,
+                });
+            }
+            #[cfg(feature = "mav2-message-signing")]
+            if let Some(signing) = signing_data {
+                if !signing.verify_signature(&frame) {
+                    return Err(FrameValidationError {
+                        frame: unverified,
+                        reason: FrameValidationErrorKind::InvalidSignature,
+                    });
+                }
+            }
+            Ok(MAVLinkMessageRaw::V2(frame))
+        }
+    }
+}
+
+/// Read the next structurally complete MAVLink 1 or 2 frame without validating it.
+///
+/// The function only uses the framing marker and encoded frame length to
+/// delimit bytes. Callers must treat the returned frame as untrusted.
+pub fn read_any_unverified<R: Read>(
+    reader: &mut PeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    loop {
+        match reader.peek_exact(consts::STX_SIZE)?[consts::STX_OFFSET] {
+            MAV_STX => {
+                return read_v1_unverified_at_stx(reader).map(MAVLinkUnverifiedFrame::V1);
+            }
+            MAV_STX_V2 => {
+                return read_v2_unverified_at_stx(reader).map(MAVLinkUnverifiedFrame::V2);
+            }
+            _ => {
+                reader.consume(consts::STX_SIZE);
+            }
+        }
+    }
+}
+
+/// Asynchronously read the next structurally complete MAVLink 1 or 2 frame without validating it.
+#[cfg(feature = "tokio")]
+pub async fn read_any_unverified_async<R: tokio::io::AsyncRead + Unpin>(
+    reader: &mut AsyncPeekReader<R>,
+) -> Result<MAVLinkUnverifiedFrame, MessageReadError> {
+    loop {
+        match reader.read_u8().await? {
+            MAV_STX => {
+                return read_v1_unverified_after_stx_async(reader)
+                    .await
+                    .map(MAVLinkUnverifiedFrame::V1);
+            }
+            MAV_STX_V2 => {
+                return read_v2_unverified_after_stx_async(reader)
+                    .await
+                    .map(MAVLinkUnverifiedFrame::V2);
+            }
+            _ => {}
+        }
+    }
 }
 
 impl MAVLinkMessageRaw {

--- a/mavlink-core/src/lib.rs
+++ b/mavlink-core/src/lib.rs
@@ -84,6 +84,9 @@
 #![deny(clippy::all)]
 #![warn(clippy::use_self)]
 
+extern crate alloc;
+
+use alloc::boxed::Box;
 use core::result::Result;
 
 #[cfg(feature = "std")]
@@ -1876,7 +1879,7 @@ impl MAVLinkUnverifiedFrame {
     /// Validate this frame against message dialect `M`.
     ///
     /// On failure the returned error retains this complete unverified frame.
-    pub fn validate<M: Message>(self) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+    pub fn validate<M: Message>(self) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
         validate_unverified_frame::<M>(self, None)
     }
 
@@ -1887,7 +1890,7 @@ impl MAVLinkUnverifiedFrame {
     pub fn validate_signed<M: Message>(
         self,
         signing_data: Option<&SigningData>,
-    ) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+    ) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
         validate_unverified_frame::<M>(self, signing_data)
     }
 }
@@ -1896,47 +1899,47 @@ impl MAVLinkUnverifiedFrame {
 fn validate_unverified_frame<M: Message>(
     unverified: MAVLinkUnverifiedFrame,
     signing_data: Option<&SigningData>,
-) -> Result<MAVLinkMessageRaw, FrameValidationError> {
+) -> Result<MAVLinkMessageRaw, Box<FrameValidationError>> {
     match unverified {
         MAVLinkUnverifiedFrame::V1(frame) => {
             if !frame.has_valid_crc::<M>() {
-                return Err(FrameValidationError {
+                return Err(Box::new(FrameValidationError {
                     frame: unverified,
                     reason: FrameValidationErrorKind::InvalidChecksum,
-                });
+                }));
             }
             #[cfg(feature = "mav2-message-signing")]
             if signing_data.is_some_and(|signing| !signing.config.allow_unsigned) {
-                return Err(FrameValidationError {
+                return Err(Box::new(FrameValidationError {
                     frame: unverified,
                     reason: FrameValidationErrorKind::UnsignedNotAllowed,
-                });
+                }));
             }
             Ok(MAVLinkMessageRaw::V1(frame))
         }
         MAVLinkUnverifiedFrame::V2(frame) => {
             let unsupported_flags = frame.incompatibility_flags() & !consts::v2::SUPPORTED_IFLAGS;
             if unsupported_flags != 0 {
-                return Err(FrameValidationError {
+                return Err(Box::new(FrameValidationError {
                     frame: unverified,
                     reason: FrameValidationErrorKind::UnsupportedIncompatibilityFlags {
                         flags: unsupported_flags,
                     },
-                });
+                }));
             }
             if !frame.has_valid_crc::<M>() {
-                return Err(FrameValidationError {
+                return Err(Box::new(FrameValidationError {
                     frame: unverified,
                     reason: FrameValidationErrorKind::InvalidChecksum,
-                });
+                }));
             }
             #[cfg(feature = "mav2-message-signing")]
             if let Some(signing) = signing_data {
                 if !signing.verify_signature(&frame) {
-                    return Err(FrameValidationError {
+                    return Err(Box::new(FrameValidationError {
                         frame: unverified,
                         reason: FrameValidationErrorKind::InvalidSignature,
-                    });
+                    }));
                 }
             }
             Ok(MAVLinkMessageRaw::V2(frame))

--- a/mavlink/tests/unverified_frame_tests.rs
+++ b/mavlink/tests/unverified_frame_tests.rs
@@ -78,8 +78,8 @@ fn validation_error_preserves_the_complete_unverified_frame() {
     };
 
     assert_eq!(error.reason, FrameValidationErrorKind::InvalidChecksum);
-    assert_eq!(error.frame.raw_bytes(), bytes);
-    assert_eq!(error.frame.message_id(), UNKNOWN_V2_ID);
+    assert_eq!(frame.raw_bytes(), bytes);
+    assert_eq!(frame.message_id(), UNKNOWN_V2_ID);
 }
 
 #[test]
@@ -122,7 +122,7 @@ fn mixed_stream_parses_the_known_frame_and_not_the_unknown_frame() {
         match frame.validate::<MavMessage>() {
             Ok(raw) => parsed_messages
                 .push(MavMessage::parse(raw.version(), raw.message_id(), raw.payload()).unwrap()),
-            Err(error) => unknown_frames.push(error.frame),
+            Err(_) => unknown_frames.push(frame),
         }
     }
 

--- a/mavlink/tests/unverified_frame_tests.rs
+++ b/mavlink/tests/unverified_frame_tests.rs
@@ -1,0 +1,161 @@
+#![cfg(feature = "dialect-common")]
+
+use mavlink::{
+    MAV_STX, MAV_STX_V2, MAVLinkUnverifiedFrame, MAVLinkV2MessageRaw, MavHeader, Message,
+    calculate_crc, dialects::common::MavMessage, error::FrameValidationErrorKind,
+    peek_reader::PeekReader,
+};
+
+const UNKNOWN_V1_ID: u8 = 255;
+const UNKNOWN_V2_ID: u32 = 0x00_ff_fe;
+const UNKNOWN_CRC_EXTRA: u8 = 123;
+const PAYLOAD: &[u8] = &[0x12, 0xfe, 0xfd, 0x34];
+
+fn unknown_v1_frame() -> Vec<u8> {
+    assert!(MavMessage::default_message_from_id(UNKNOWN_V1_ID.into()).is_none());
+    let mut frame = vec![MAV_STX, PAYLOAD.len() as u8, 42, 7, 8, UNKNOWN_V1_ID];
+    frame.extend_from_slice(PAYLOAD);
+    let checksum = calculate_crc(&frame[1..], UNKNOWN_CRC_EXTRA);
+    frame.extend_from_slice(&checksum.to_le_bytes());
+    frame
+}
+
+fn unknown_v2_frame() -> Vec<u8> {
+    assert!(MavMessage::default_message_from_id(UNKNOWN_V2_ID).is_none());
+    let id = UNKNOWN_V2_ID.to_le_bytes();
+    let mut frame = vec![
+        MAV_STX_V2,
+        PAYLOAD.len() as u8,
+        0,
+        0,
+        43,
+        9,
+        10,
+        id[0],
+        id[1],
+        id[2],
+    ];
+    frame.extend_from_slice(PAYLOAD);
+    let checksum = calculate_crc(&frame[1..], UNKNOWN_CRC_EXTRA);
+    frame.extend_from_slice(&checksum.to_le_bytes());
+    frame
+}
+
+fn known_v2_frame() -> Vec<u8> {
+    let message = MavMessage::default_message_from_id(0).unwrap();
+    let mut raw = MAVLinkV2MessageRaw::new();
+    raw.serialize_message(MavHeader::default(), &message);
+    raw.raw_bytes().to_vec()
+}
+
+#[test]
+fn low_level_reader_returns_unknown_frames_without_verification() {
+    let v1 = unknown_v1_frame();
+    let v2 = unknown_v2_frame();
+    let bytes = [v1.as_slice(), v2.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let first = mavlink::read_any_unverified(&mut reader).unwrap();
+    let second = mavlink::read_any_unverified(&mut reader).unwrap();
+
+    assert!(matches!(first, MAVLinkUnverifiedFrame::V1(_)));
+    assert_eq!(first.raw_bytes(), v1);
+    assert_eq!(first.message_id(), u32::from(UNKNOWN_V1_ID));
+    assert!(matches!(second, MAVLinkUnverifiedFrame::V2(_)));
+    assert_eq!(second.raw_bytes(), v2);
+    assert_eq!(second.message_id(), UNKNOWN_V2_ID);
+}
+
+#[test]
+fn validation_error_preserves_the_complete_unverified_frame() {
+    let bytes = unknown_v2_frame();
+    let mut reader = PeekReader::new(bytes.as_slice());
+    let frame = mavlink::read_v2_unverified(&mut reader).unwrap();
+
+    let error = match frame.validate::<MavMessage>() {
+        Ok(_) => panic!("unknown frame unexpectedly validated"),
+        Err(error) => error,
+    };
+
+    assert_eq!(error.reason, FrameValidationErrorKind::InvalidChecksum);
+    assert_eq!(error.frame.raw_bytes(), bytes);
+    assert_eq!(error.frame.message_id(), UNKNOWN_V2_ID);
+}
+
+#[test]
+fn existing_validated_reader_keeps_discarding_invalid_candidates() {
+    let unknown = unknown_v2_frame();
+    let known = known_v2_frame();
+    let bytes = [unknown.as_slice(), known.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let received = mavlink::read_v2_raw_message::<MavMessage, _>(&mut reader).unwrap();
+
+    assert_eq!(received.raw_bytes(), known);
+}
+
+#[test]
+fn unverified_frame_can_be_validated_against_a_known_dialect() {
+    let bytes = known_v2_frame();
+    let mut reader = PeekReader::new(bytes.as_slice());
+    let frame = mavlink::read_v2_unverified(&mut reader).unwrap();
+
+    let validated = frame.validate::<MavMessage>().unwrap();
+
+    assert_eq!(validated.message_id(), 0);
+    assert!(matches!(validated, mavlink::MAVLinkMessageRaw::V2(_)));
+}
+
+#[test]
+fn mixed_stream_parses_the_known_frame_and_not_the_unknown_frame() {
+    let known = known_v2_frame();
+    let unknown = unknown_v2_frame();
+    let bytes = [known.as_slice(), unknown.as_slice()].concat();
+    let mut reader = PeekReader::new(bytes.as_slice());
+    let mut parsed_messages = Vec::new();
+    let mut unknown_frames = Vec::new();
+
+    for _i in 0..2 {
+        let frame = mavlink::read_any_unverified(&mut reader).unwrap();
+        // let frame = mavlink::read_v2_unverified(&mut reader).unwrap();
+
+        match frame.validate::<MavMessage>() {
+            Ok(raw) => parsed_messages
+                .push(MavMessage::parse(raw.version(), raw.message_id(), raw.payload()).unwrap()),
+            Err(error) => unknown_frames.push(error.frame),
+        }
+    }
+
+    assert!(matches!(&parsed_messages[0], MavMessage::HEARTBEAT(_)));
+    assert_eq!(parsed_messages.len(), 1);
+    assert_eq!(unknown_frames.len(), 1);
+    assert_eq!(unknown_frames[0].message_id(), UNKNOWN_V2_ID);
+    assert_eq!(unknown_frames[0].raw_bytes(), unknown);
+}
+
+#[test]
+fn low_level_reader_makes_no_checksum_claim() {
+    let mut bytes = unknown_v1_frame();
+    *bytes.last_mut().unwrap() ^= 0xff;
+    let mut reader = PeekReader::new(bytes.as_slice());
+
+    let frame = mavlink::read_v1_unverified(&mut reader).unwrap();
+
+    assert_eq!(frame.raw_bytes(), bytes);
+}
+
+#[cfg(feature = "tokio")]
+#[tokio::test]
+async fn async_low_level_reader_returns_unknown_frame() {
+    use mavlink::async_peek_reader::AsyncPeekReader;
+
+    let bytes = unknown_v2_frame();
+    let mut reader = AsyncPeekReader::new(bytes.as_slice());
+
+    let frame = mavlink::read_any_unverified_async(&mut reader)
+        .await
+        .unwrap();
+
+    assert_eq!(frame.raw_bytes(), bytes);
+    assert_eq!(frame.message_id(), UNKNOWN_V2_ID);
+}


### PR DESCRIPTION
Implemented receiving unverified frames as we've discussed here: github.com/mavlink/rust-mavlink/pull/530#issuecomment-5401801760
and the resulted issue: https://github.com/mavlink/rust-mavlink/issues/533


