### PR TITLE
build: patches: Add move_mav_cmd_external_position_estimate_to_common

### DIFF
--- a/build/patches/move_mav_cmd_external_position_estimate_to_common.patch
+++ b/build/patches/move_mav_cmd_external_position_estimate_to_common.patch
@@ -1,0 +1,21 @@
+diff --git a/message_definitions/v1.0/common.xml b/message_definitions/v1.0/common.xml
+index 1ccad64..4075347 100644
+--- a/message_definitions/v1.0/common.xml
++++ b/message_definitions/v1.0/common.xml
+@@ -2550,6 +2550,16 @@
+         <param index="6">Reserved</param>
+         <param index="7">Reserved</param>
+       </entry>
++      <entry value="43003" name="MAV_CMD_EXTERNAL_POSITION_ESTIMATE" hasLocation="true" isDestination="false">
++        <description>Provide an external position estimate for use when dead-reckoning. This is meant to be used for occasional position resets that may be provided by a external system such as a remote pilot using landmarks over a video link.</description>
++        <param index="1" label="transmission_time" units="s">Timestamp that this message was sent as a time in the transmitters time domain. The sender should wrap this time back to zero based on required timing accuracy for the application and the limitations of a 32 bit float. For example, wrapping at 10 hours would give approximately 1ms accuracy. Recipient must handle time wrap in any timing jitter correction applied to this field. Wrap rollover time should not be at not more than 250 seconds, which would give approximately 10 microsecond accuracy.</param>
++        <param index="2" label="processing_time" units="s">The time spent in processing the sensor data that is the basis for this position. The recipient can use this to improve time alignment of the data. Set to zero if not known.</param>
++        <param index="3" label="accuracy">estimated one standard deviation accuracy of the measurement. Set to NaN if not known.</param>
++        <param index="4">Empty</param>
++        <param index="5" label="Latitude">Latitude</param>
++        <param index="6" label="Longitude">Longitude</param>
++        <param index="7" label="Altitude" units="m">Altitude, not used. Should be sent as NaN. May be supported in a future version of this message.</param>
++      </entry>
+       <!-- END of payload range (30000 to 30999) -->
+       <!-- BEGIN user defined range (31000 to 31999) -->
+       <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1" hasLocation="true" isDestination="true">


### PR DESCRIPTION
Allow usage of MAV_CMD_EXTERNAL_POSITION_ESTIMATE, this is a common request

0.10 has a bug that only common MAV_CMD can be used